### PR TITLE
racketのCRUD機能の実装

### DIFF
--- a/app/Http/Controllers/RacketController.php
+++ b/app/Http/Controllers/RacketController.php
@@ -63,7 +63,17 @@ class RacketController extends Controller
      */
     public function show($id)
     {
-        //
+        try {
+            $racket = Racket::with(['maker', 'racketImages'])->findOrFail($id);
+
+            return response()->json($racket, 200);
+        } catch (\ModelNotFoundException $e) {
+            throw $e;
+        } catch (\Throwable $e) {
+            \Log::error($e);
+
+            throw $e;
+        }
     }
 
     /**

--- a/app/Http/Controllers/RacketController.php
+++ b/app/Http/Controllers/RacketController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
 use App\Models\Racket;
+use App\Http\Requests\Racket\RacketStoreRequest;
 
 class RacketController extends Controller
 {
@@ -31,9 +32,27 @@ class RacketController extends Controller
      * @param  \Illuminate\Http\Request  $request
      * @return \Illuminate\Http\Response
      */
-    public function store(Request $request)
+    public function store(RacketStoreRequest $request)
     {
-        //
+        $validated = $request->validated();
+
+        try {
+            $racket = Racket::create([
+                'name_ja' => $validated['name_ja'],
+                'name_en' => $validated['name_en'],
+                'maker_id' => $validated['maker_id'],
+                'image_id' => isset($validated['image_id']) ? $validated['image_id'] : null,
+                'need_posting_image' => $validated['need_posting_image'],
+            ]);
+
+            if ($racket) {
+                return response()->json('ラケットを登録しました', 200);
+            }
+        } catch (\Throwable $e) {
+            \Log::error($e);
+
+            throw $e;
+        }
     }
 
     /**

--- a/app/Http/Controllers/RacketController.php
+++ b/app/Http/Controllers/RacketController.php
@@ -117,6 +117,18 @@ class RacketController extends Controller
      */
     public function destroy($id)
     {
-        //
+        try {
+            $racket = Racket::findOrFail($id);
+
+            if ($racket->delete()) {
+                return response()->json("{$racket->name_ja}を削除しました", 200);
+            }
+        } catch (\ModelNotFoundException $e) {
+            throw $e;
+        } catch (\Throwable $e) {
+            \Log::error($e);
+
+            throw $e;
+        }
     }
 }

--- a/app/Http/Controllers/RacketController.php
+++ b/app/Http/Controllers/RacketController.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class RacketController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function index()
+    {
+        //
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function store(Request $request)
+    {
+        //
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function show($id)
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function update(Request $request, $id)
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy($id)
+    {
+        //
+    }
+}

--- a/app/Http/Controllers/RacketController.php
+++ b/app/Http/Controllers/RacketController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use Illuminate\Http\Request;
 use App\Models\Racket;
 use App\Http\Requests\Racket\RacketStoreRequest;
+use App\Http\Requests\Racket\RacketUpdateRequest;
 
 class RacketController extends Controller
 {
@@ -83,9 +84,29 @@ class RacketController extends Controller
      * @param  int  $id
      * @return \Illuminate\Http\Response
      */
-    public function update(Request $request, $id)
+    public function update(RacketUpdateRequest $request, $id)
     {
-        //
+        $validated = $request->validated();
+
+        try {
+            $racket = Racket::findOrFail($id);
+
+            $racket->name_ja = $validated['name_ja'];
+            $racket->name_en = $validated['name_en'];
+            $racket->maker_id = $validated['maker_id'];
+            $racket->image_id = isset($validated['image_id']) ? $validated['image_id'] : null;
+            $racket->need_posting_image = $validated['need_posting_image'];
+
+            if ($racket->save()) {
+                return response()->json('ラケット情報を更新しました', 200);
+            }
+        } catch (\ModelNotFoundException $e) {
+            throw $e;
+        } catch (\Throwable $e) {
+            \Log::error($e);
+
+            throw $e;
+        }
     }
 
     /**

--- a/app/Http/Controllers/RacketController.php
+++ b/app/Http/Controllers/RacketController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
+use App\Models\Racket;
 
 class RacketController extends Controller
 {
@@ -13,7 +14,15 @@ class RacketController extends Controller
      */
     public function index()
     {
-        //
+        try {
+            $rackets = Racket::with(['maker', 'racketImages'])->get();
+
+            return response()->json($rackets, 200);
+        } catch (\Throwable $e) {
+            \Log::error($e);
+
+            throw $e;
+        }
     }
 
     /**

--- a/app/Http/Requests/Racket/RacketStoreRequest.php
+++ b/app/Http/Requests/Racket/RacketStoreRequest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Requests\Racket;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class RacketStoreRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules()
+    {
+        return [
+            'name_ja' => ['required', 'max:30'],
+            'name_en' => ['max:30'],
+            'maker_id' => ['required', 'integer', 'exists:makers,id'],
+            'image_id' => ['sometimes', 'integer', 'exists:racket_images,id'],
+            'need_posting_image' => ['required','boolean']
+        ];
+    }
+}

--- a/app/Http/Requests/Racket/RacketUpdateRequest.php
+++ b/app/Http/Requests/Racket/RacketUpdateRequest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Requests\Racket;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class RacketUpdateRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules()
+    {
+        return [
+            'name_ja' => ['required', 'max:30'],
+            'name_en' => ['max:30'],
+            'maker_id' => ['required', 'integer', 'exists:makers,id'],
+            'image_id' => ['sometimes', 'integer', 'exists:racket_images,id'],
+            'need_posting_image' => ['required','boolean']
+        ];
+    }
+}

--- a/app/Models/Maker.php
+++ b/app/Models/Maker.php
@@ -17,4 +17,9 @@ class Maker extends Model
     public function guts() {
         return $this->hasMany(Gut::class);
     }
+
+    public function rackets()
+    {
+        return $this->hasMany(Racket::class);
+    }
 }

--- a/app/Models/Racket.php
+++ b/app/Models/Racket.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Racket extends Model
+{
+    use HasFactory;
+}

--- a/app/Models/Racket.php
+++ b/app/Models/Racket.php
@@ -8,4 +8,14 @@ use Illuminate\Database\Eloquent\Model;
 class Racket extends Model
 {
     use HasFactory;
+
+    public function maker()
+    {
+        return $this->belongsTo(Maker::class);
+    }
+
+    public function racketImages()
+    {
+        return $this->hasMany(RacketImage::class, 'id', 'image_id');
+    }
 }

--- a/app/Models/Racket.php
+++ b/app/Models/Racket.php
@@ -9,6 +9,14 @@ class Racket extends Model
 {
     use HasFactory;
 
+    protected $fillable = [
+        'name_ja',
+        'name_en',
+        'maker_id',
+        'image_id',
+        'need_posting_image'
+    ];
+
     public function maker()
     {
         return $this->belongsTo(Maker::class);

--- a/app/Models/RacketImage.php
+++ b/app/Models/RacketImage.php
@@ -13,4 +13,9 @@ class RacketImage extends Model
         'file_path',
         'title'
     ];
+
+    public function racket()
+    {
+        return $this->belongsTo(Racket::class, 'id','image_id');
+    }
 }

--- a/database/migrations/2023_11_15_141948_create_rackets_table.php
+++ b/database/migrations/2023_11_15_141948_create_rackets_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('rackets', function (Blueprint $table) {
+            $table->id();
+            $table->string('name_ja', 30)->nullable(false);
+            $table->string('name_en', 30);
+            $table->foreignId('maker_id')->constrained('makers');
+            $table->foreignId('image_id')->nullable()->constrained('racket_images');
+            $table->boolean('need_posting_image')->nullable(false)->default(true);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('rackets');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -21,6 +21,7 @@ class DatabaseSeeder extends Seeder
             RacketImageSeeder::class,
             GutImageSeeder::class,
             GutSeeder::class,
+            RacketSeeder::class,
             UserSeeder::class,
             AdminSeeder::class
         ]);

--- a/database/seeders/RacketSeeder.php
+++ b/database/seeders/RacketSeeder.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+use Carbon\Carbon;
+
+class RacketSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        DB::table('rackets')->insert([
+            [
+                'name_ja' => 'ピュアアエロ',
+                'name_en' => 'pure aero',
+                'maker_id' => 2,
+                'image_id' => 2,
+                'need_posting_image' => true,
+                'created_at' => Carbon::now(),
+                'updated_at' => Carbon::now()
+            ],
+            [
+                'name_ja' => 'Vコア 100',
+                'name_en' => 'Vcore 100',
+                'maker_id' => 1,
+                'image_id' => null,
+                'need_posting_image' => true,
+                'created_at' => Carbon::now(),
+                'updated_at' => Carbon::now()
+            ],
+            [
+                'name_ja' => 'プロスタッフ95',
+                'name_en' => 'prostaf95',
+                'maker_id' => 3,
+                'image_id' => 1,
+                'need_posting_image' => true,
+                'created_at' => Carbon::now(),
+                'updated_at' => Carbon::now()
+            ],
+        ]);
+    }
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,6 +3,7 @@
 use App\Http\Controllers\GutController;
 use App\Http\Controllers\GutImageController;
 use App\Http\Controllers\MakerController;
+use App\Http\Controllers\RacketController;
 use App\Http\Controllers\RacketImageController;
 use App\Models\GutImage;
 use Illuminate\Support\Facades\Route;
@@ -35,3 +36,5 @@ Route::apiResource('api/gut_images', GutImageController::class);
 Route::apiResource('api/racket_images', RacketImageController::class);
 
 Route::apiResource('api/guts', GutController::class);
+
+Route::apiResource('api/rackets', RacketController::class);


### PR DESCRIPTION
やったこと：
- racketのマイグレーションファイルの作成
- model間のリレーションの設定
- racket一覧情報取得apiの実装indexメソッド
- racket登録機能apiの実装storeメソッド
- racket詳細情報取得apiの実装showメソッド
- racket情報更新apiの実装indexメソッド
- racket情報削除apiの実装indexメソッド

レビューお願いします。