### PR TITLE
GutImageControllerの各メソッドにauthのmiddlewareを設定

### DIFF
--- a/app/Http/Controllers/GutImageController.php
+++ b/app/Http/Controllers/GutImageController.php
@@ -11,6 +11,11 @@ use Illuminate\Database\Eloquent\ModelNotFoundException;
 
 class GutImageController extends Controller
 {
+    public function __construct()
+    {
+        $this->middleware('auth:admin')->except('store');
+    }
+    
     /**
      * Display a listing of the resource.
      *


### PR DESCRIPTION
ガット画像はユーザーからの提供も受けるのでstoreメソッド以外にAuth:adminミドルウェアを設定し、storeメソッドはuser,admin両者とも利用できるようにしました。

レビューお願いします。