### PR TITLE
add: tennis_profileのCRUD機能の実装

### DIFF
--- a/app/Http/Controllers/TennisProfileController.php
+++ b/app/Http/Controllers/TennisProfileController.php
@@ -62,7 +62,17 @@ class TennisProfileController extends Controller
      */
     public function show($id)
     {
-        //
+        try {
+            $tennis_profile = TennisProfile::with(['user', 'racket'])->get();
+    
+            return response()->json($tennis_profile, 200);
+        } catch(\ModelNotFoundException $e) {
+            throw $e;
+        } catch(\Throwable $e) {
+            \Log::error($e);
+
+            throw $e;
+        }
     }
 
     /**

--- a/app/Http/Controllers/TennisProfileController.php
+++ b/app/Http/Controllers/TennisProfileController.php
@@ -16,7 +16,15 @@ class TennisProfileController extends Controller
      */
     public function index()
     {
-        //
+        try {
+            $tennis_profiles = TennisProfile::with(['user', 'racket'])->get();
+
+            return response()->json($tennis_profiles, 200);
+        } catch (\Throwable $e) {
+            \Log::error($e);
+
+            throw $e;
+        }
     }
 
     /**

--- a/app/Http/Controllers/TennisProfileController.php
+++ b/app/Http/Controllers/TennisProfileController.php
@@ -3,6 +3,8 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
+use App\Models\TennisProfile;
+use App\Http\Requests\TennisProfile\TennisProfileStoreRequest;
 
 class TennisProfileController extends Controller
 {
@@ -22,9 +24,34 @@ class TennisProfileController extends Controller
      * @param  \Illuminate\Http\Request  $request
      * @return \Illuminate\Http\Response
      */
-    public function store(Request $request)
+    public function store(TennisProfileStoreRequest $request)
     {
-        //
+        $validated = $request->validated();
+
+        try {
+            $tennis_profile = TennisProfile::create([
+                'user_id'           => $validated['user_id'],
+                'gender'            => $validated['gender'],
+                'my_racket_id'      => empty($validated['my_racket_id']) ? null : $validated['my_racket_id'],
+                'grip_form'         => $validated['grip_form'],
+                'height'            => $validated['height'],
+                'age'               => $validated['age'],
+                'physique'          => $validated['physique'],
+                'experience_period' => $validated['experience_period'],
+                'frequency'         => $validated['frequency'],
+                'play_style'        => $validated['play_style'],
+                'favarit_shot'      => $validated['favarit_shot'],
+                'weak_shot'         => $validated['weak_shot'],
+            ]);
+
+            if ($tennis_profile) {
+                return response()->json('テニスプロフィールと登録しました', 200);
+            }
+        } catch (\Throwable $e) {
+            \Log::error($e);
+
+            return $e;
+        }
     }
 
     /**

--- a/app/Http/Controllers/TennisProfileController.php
+++ b/app/Http/Controllers/TennisProfileController.php
@@ -54,7 +54,7 @@ class TennisProfileController extends Controller
             ]);
 
             if ($tennis_profile) {
-                return response()->json('テニスプロフィールと登録しました', 200);
+                return response()->json('テニスプロフィールを登録しました', 200);
             }
         } catch (\Throwable $e) {
             \Log::error($e);

--- a/app/Http/Controllers/TennisProfileController.php
+++ b/app/Http/Controllers/TennisProfileController.php
@@ -72,7 +72,7 @@ class TennisProfileController extends Controller
     public function show($id)
     {
         try {
-            $tennis_profile = TennisProfile::with(['user', 'racket'])->get();
+            $tennis_profile = TennisProfile::with(['user', 'racket'])->findOrFail($id);
 
             return response()->json($tennis_profile, 200);
         } catch (\ModelNotFoundException $e) {

--- a/app/Http/Controllers/TennisProfileController.php
+++ b/app/Http/Controllers/TennisProfileController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use Illuminate\Http\Request;
 use App\Models\TennisProfile;
 use App\Http\Requests\TennisProfile\TennisProfileStoreRequest;
+use App\Http\Requests\TennisProfile\TennisProfileUpdateRequest;
 
 class TennisProfileController extends Controller
 {
@@ -64,11 +65,11 @@ class TennisProfileController extends Controller
     {
         try {
             $tennis_profile = TennisProfile::with(['user', 'racket'])->get();
-    
+
             return response()->json($tennis_profile, 200);
-        } catch(\ModelNotFoundException $e) {
+        } catch (\ModelNotFoundException $e) {
             throw $e;
-        } catch(\Throwable $e) {
+        } catch (\Throwable $e) {
             \Log::error($e);
 
             throw $e;
@@ -82,9 +83,35 @@ class TennisProfileController extends Controller
      * @param  int  $id
      * @return \Illuminate\Http\Response
      */
-    public function update(Request $request, $id)
+    public function update(TennisProfileUpdateRequest $request, $id)
     {
-        //
+        $validated = $request->validated();
+        
+        try {
+            $tennis_profile = TennisProfile::findOrFail($id);
+
+            $tennis_profile->gender            = $validated['gender'];
+            $tennis_profile->my_racket_id      = empty($validated['my_racket_id']) ? null : $validated['my_racket_id'];
+            $tennis_profile->grip_form         = $validated['grip_form'];
+            $tennis_profile->height            = $validated['height'];
+            $tennis_profile->age               = $validated['age'];
+            $tennis_profile->physique          = $validated['physique'];
+            $tennis_profile->experience_period = $validated['experience_period'];
+            $tennis_profile->frequency         = $validated['frequency'];
+            $tennis_profile->play_style        = $validated['play_style'];
+            $tennis_profile->favarit_shot      = $validated['favarit_shot'];
+            $tennis_profile->weak_shot         = $validated['weak_shot'];
+
+            if ($tennis_profile->save()) {
+                return response()->json('テニスプロフィールを更新しました', 200);
+            }
+        } catch (\ModelNotFoundException $e) {
+            throw $e;
+        } catch (\Throwable $e) {
+            \Log::error($e);
+
+            return $e;
+        }
     }
 
     /**

--- a/app/Http/Controllers/TennisProfileController.php
+++ b/app/Http/Controllers/TennisProfileController.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class TennisProfileController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function index()
+    {
+        //
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function store(Request $request)
+    {
+        //
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function show($id)
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function update(Request $request, $id)
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy($id)
+    {
+        //
+    }
+}

--- a/app/Http/Requests/TennisProfile/TennisProfileStoreRequest.php
+++ b/app/Http/Requests/TennisProfile/TennisProfileStoreRequest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Requests\TennisProfile;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class TennisProfileStoreRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules()
+    {
+        return [
+            'user_id'           => ['required', 'integer', 'exists:users,id', 'unique:tennis_profiles,user_id'],
+            'gender'            => ['required', 'string', 'max:15'],
+            'my_racket_id'      => ['sometimes', 'integer', 'exists:rackets,id'],
+            'grip_form'         => ['required', 'string', 'max:15'],
+            'height'            => ['required', 'string', 'max:20'],
+            'age'               => ['required', 'string', 'max:15'],
+            'physique'          => ['required', 'string', 'max:15'],
+            'experience_period' => ['required', 'integer', 'max:120'],
+            'frequency'         => ['required', 'string', 'max:20'],
+            'play_style'        => ['required', 'string', 'max:20'],
+            'favarit_shot'      => ['required', 'string', 'max:20'],
+            'weak_shot'         => ['required', 'string', 'max:20'],
+        ];
+    }
+}

--- a/app/Http/Requests/TennisProfile/TennisProfileUpdateRequest.php
+++ b/app/Http/Requests/TennisProfile/TennisProfileUpdateRequest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Http\Requests\TennisProfile;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class TennisProfileUpdateRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules()
+    {
+        return [
+            'gender'            => ['required', 'string', 'max:15'],
+            'my_racket_id'      => ['sometimes', 'integer', 'exists:rackets,id'],
+            'grip_form'         => ['required', 'string', 'max:15'],
+            'height'            => ['required', 'string', 'max:20'],
+            'age'               => ['required', 'string', 'max:15'],
+            'physique'          => ['required', 'string', 'max:15'],
+            'experience_period' => ['required', 'integer', 'max:120'],
+            'frequency'         => ['required', 'string', 'max:20'],
+            'play_style'        => ['required', 'string', 'max:20'],
+            'favarit_shot'      => ['required', 'string', 'max:20'],
+            'weak_shot'         => ['required', 'string', 'max:20'],
+        ];
+    }
+}

--- a/app/Models/Racket.php
+++ b/app/Models/Racket.php
@@ -26,4 +26,9 @@ class Racket extends Model
     {
         return $this->hasMany(RacketImage::class, 'id', 'image_id');
     }
+
+    public function tennisProfiles()
+    {
+        return $this->hasMany(TennisProfile::class, 'my_racket_id', 'id');
+    }
 }

--- a/app/Models/TennisProfile.php
+++ b/app/Models/TennisProfile.php
@@ -8,4 +8,14 @@ use Illuminate\Database\Eloquent\Model;
 class TennisProfile extends Model
 {
     use HasFactory;
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function racket()
+    {
+        return $this->belongsTo(Racket::class, 'my_racket_id', 'id');
+    }
 }

--- a/app/Models/TennisProfile.php
+++ b/app/Models/TennisProfile.php
@@ -9,6 +9,21 @@ class TennisProfile extends Model
 {
     use HasFactory;
 
+    protected $fillable = [
+        'user_id',
+        'gender',
+        'my_racket_id',
+        'grip_form',
+        'height',
+        'age',
+        'physique',
+        'experience_period',
+        'frequency',
+        'play_style',
+        'favarit_shot',
+        'weak_shot'
+    ];
+
     public function user()
     {
         return $this->belongsTo(User::class);

--- a/app/Models/TennisProfile.php
+++ b/app/Models/TennisProfile.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class TennisProfile extends Model
+{
+    use HasFactory;
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -41,4 +41,9 @@ class User extends Authenticatable
     protected $casts = [
         'email_verified_at' => 'datetime',
     ];
+
+    public function tennisProfile()
+    {
+        return $this->hasOne(TennisProfile::class);
+    }
 }

--- a/database/migrations/2023_11_16_052500_create_tennis_profiles_table.php
+++ b/database/migrations/2023_11_16_052500_create_tennis_profiles_table.php
@@ -15,7 +15,7 @@ return new class extends Migration
     {
         Schema::create('tennis_profiles', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('user_id')->constrained('users')->cascadeOnDelete();
+            $table->foreignId('user_id')->unique()->constrained('users')->cascadeOnDelete();
             $table->string('gender', 15)->default('未設定');
             $table->foreignId('my_racket_id')->nullable()->constrained('rackets');
             $table->string('grip_form', 20)->default('未設定');

--- a/database/migrations/2023_11_16_052500_create_tennis_profiles_table.php
+++ b/database/migrations/2023_11_16_052500_create_tennis_profiles_table.php
@@ -15,7 +15,7 @@ return new class extends Migration
     {
         Schema::create('tennis_profiles', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('user_id')->constrained('users');
+            $table->foreignId('user_id')->constrained('users')->cascadeOnDelete();
             $table->string('gender', 15)->default('未設定');
             $table->foreignId('my_racket_id')->nullable()->constrained('rackets');
             $table->string('grip_form', 20)->default('未設定');

--- a/database/migrations/2023_11_16_052500_create_tennis_profiles_table.php
+++ b/database/migrations/2023_11_16_052500_create_tennis_profiles_table.php
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('tennis_profiles', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained('users');
+            $table->string('gender', 15)->default('未設定');
+            $table->foreignId('my_racket_id')->nullable()->constrained('rackets');
+            $table->string('grip_form', 20)->default('未設定');
+            $table->string('height', 20)->default('未設定');
+            $table->string('age', 20)->default('未設定');
+            $table->string('physique', 20)->default('未設定');
+            $table->integer('experience_period')->unsigned()->default(0);
+            $table->string('frequency', 20)->default('未設定');
+            $table->string('play_style', 20)->default('未設定');
+            $table->string('favarit_shot', 20)->default('未設定');
+            $table->string('weak_shot', 20);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('tennis_profiles');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -23,7 +23,8 @@ class DatabaseSeeder extends Seeder
             GutSeeder::class,
             RacketSeeder::class,
             UserSeeder::class,
-            AdminSeeder::class
+            AdminSeeder::class,
+            TennisProfileSeeder::class,
         ]);
 
         // \App\Models\User::factory(10)->create();

--- a/database/seeders/TennisProfileSeeder.php
+++ b/database/seeders/TennisProfileSeeder.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+use Carbon\Carbon;
+
+class TennisProfileSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        DB::table('tennis_profiles')->insert([
+            [
+                'user_id' => 1,
+                'gender' => 'male',
+                'my_racket_id' => 1,
+                'grip_form' => 'ウエスタン',
+                'height' => '普通',
+                'age' => '30代前半',
+                'physique' => 'がっしり',
+                'experience_period' => 10,
+                'frequency' => '週１回',
+                'play_style' => 'オールラウンダー',
+                'favarit_shot' => 'サーブ',
+                'weak_shot' => 'バックハンド',
+                'created_at' => Carbon::now(),
+                'updated_at' => Carbon::now()
+            ],
+            [
+                'user_id' => 2,
+                'gender' => 'female',
+                'my_racket_id' => 1,
+                'grip_form' => 'フルウエスタン',
+                'height' => 'やや小柄',
+                'age' => '20代前半',
+                'physique' => '普通',
+                'experience_period' => 3,
+                'frequency' => '月2回',
+                'play_style' => 'オールラウンダー',
+                'favarit_shot' => 'フォアハンド',
+                'weak_shot' => 'バックハンド',
+                'created_at' => Carbon::now(),
+                'updated_at' => Carbon::now()
+            ],
+        ]);
+    }
+}

--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -32,6 +32,34 @@ class UserSeeder extends Seeder
                 'created_at' => Carbon::now(),
                 'updated_at' => Carbon::now()
             ],
+            [
+                'name' => 'test3',
+                'email' => 'test3@test3.com',
+                'password' => Hash::make('test3test3'),
+                'created_at' => Carbon::now(),
+                'updated_at' => Carbon::now()
+            ],
+            [
+                'name' => 'test4',
+                'email' => 'test4@test4.com',
+                'password' => Hash::make('test4test4'),
+                'created_at' => Carbon::now(),
+                'updated_at' => Carbon::now()
+            ],
+            [
+                'name' => 'test5',
+                'email' => 'test5@test5.com',
+                'password' => Hash::make('test5test5'),
+                'created_at' => Carbon::now(),
+                'updated_at' => Carbon::now()
+            ],
+            [
+                'name' => 'test6',
+                'email' => 'test6@test6.com',
+                'password' => Hash::make('test6test6'),
+                'created_at' => Carbon::now(),
+                'updated_at' => Carbon::now()
+            ],
         ]);
     }
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -5,6 +5,7 @@ use App\Http\Controllers\GutImageController;
 use App\Http\Controllers\MakerController;
 use App\Http\Controllers\RacketController;
 use App\Http\Controllers\RacketImageController;
+use App\Http\Controllers\TennisProfileController;
 use App\Models\GutImage;
 use Illuminate\Support\Facades\Route;
 
@@ -38,3 +39,5 @@ Route::apiResource('api/racket_images', RacketImageController::class);
 Route::apiResource('api/guts', GutController::class);
 
 Route::apiResource('api/rackets', RacketController::class);
+
+Route::apiResource('api/tennis_profiles', TennisProfileController::class);


### PR DESCRIPTION
やったこと：
- tennis_profile登録機能の実装storeメソッド
- tennis_profile詳細情報取得apiの実装showメソッド
- tennis_profile更新apiの実装updateメソッド
- tennis_profile一覧情報取得apiの実装indexメソッド
- tennis_prifileのuser_idカラムにcascadeOnDelete設定

destroyメソッドはUsersテーブルとのカスケードでUserデリート時に一緒にそのユーザーのtennis_profileも削除されるようにしました。

レビューお願いします。