### PR TITLE
user新規登録時にtennis_profileも同時に作成するように変更

### DIFF
--- a/database/migrations/2023_11_16_052500_create_tennis_profiles_table.php
+++ b/database/migrations/2023_11_16_052500_create_tennis_profiles_table.php
@@ -26,7 +26,7 @@ return new class extends Migration
             $table->string('frequency', 20)->default('未設定');
             $table->string('play_style', 20)->default('未設定');
             $table->string('favarit_shot', 20)->default('未設定');
-            $table->string('weak_shot', 20);
+            $table->string('weak_shot', 20)->default('未設定');
             $table->timestamps();
         });
     }


### PR DESCRIPTION
issue: #9 
やったこと；
App\Http\Controller\User\Auth\RegisteredControllerを編集し、user新規作成後、続けてtennis_profileを作成する容易にした。
try,catchでエラーハンドリングしつつ、userとtennis_profileの整合性をtransactionを使って担保しました。
また、tennis_profileのweak_shotカラムにデフォルト値が設定されていなかったためマイグレーションを編集しデフォルト値を設定しました。

レビューお願いします。