### PR TITLE
add: makerコントローラ、ルーティングにauth:adminミドルウェアを設定

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -33,7 +33,7 @@ Route::get('/', function () {
 // require __DIR__.'/user/api.php';
 
 
-Route::apiResource('api/makers', MakerController::class);
+Route::middleware('auth:admin')->apiResource('api/makers', MakerController::class);
 
 Route::apiResource('api/gut_images', GutImageController::class);
 


### PR DESCRIPTION
makerの情報は基本的にすべて管理者のみ詳細などを確認作成するため、コントローラーのコンストラクタではなくroutingの方にmiddlweare(auth:admin)を設定しました。

確認お願いします