### PR TITLE
modify: フロント側に認証状態を判断させるため、userログイン時にlaravel_sessionとは別にcookieで'login'をセット

### DIFF
--- a/app/Http/Controllers/User/Auth/AuthenticatedSessionController.php
+++ b/app/Http/Controllers/User/Auth/AuthenticatedSessionController.php
@@ -7,6 +7,7 @@ use App\Http\Requests\Auth\LoginRequest;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Cookie;
 
 class AuthenticatedSessionController extends Controller
 {
@@ -18,6 +19,10 @@ class AuthenticatedSessionController extends Controller
         $request->authenticate();
 
         $request->session()->regenerate();
+
+        $oneWeek = 7 * 24 * 60;
+
+        Cookie::queue('login', 'yes', $oneWeek);
 
         return response()->noContent();
     }
@@ -32,6 +37,10 @@ class AuthenticatedSessionController extends Controller
         $request->session()->invalidate();
 
         $request->session()->regenerateToken();
+
+        if(Cookie::get('login')) {
+            Cookie::queue(Cookie::forget('login'));
+        }
 
         return response()->noContent();
     }


### PR DESCRIPTION
issue: #25 

やったこと；
- AuthenticatedSessionController.phpにてstoreメソッド内にcookie loginをログイン時に付与する処理を記載
- 同じくdestroyメソッドにてcookie loginが設定されていた場合ログアウト処理時に削除するように記載

理由：
フロント側でログイン後の認証状態を判断する情報を与えるためcookie loginを設定してその値の有無でフロント側で認証状態による振る舞いのコントロールをできるようにした。

レビューお願いします