### PR TITLE
modify: racketsとracketImagesテーブルのリレーションの修正

### DIFF
--- a/app/Http/Controllers/RacketController.php
+++ b/app/Http/Controllers/RacketController.php
@@ -23,7 +23,7 @@ class RacketController extends Controller
     public function index()
     {
         try {
-            $rackets = Racket::with(['maker', 'racketImages'])->get();
+            $rackets = Racket::with(['maker', 'racketImage'])->get();
 
             return response()->json($rackets, 200);
         } catch (\Throwable $e) {
@@ -71,7 +71,7 @@ class RacketController extends Controller
     public function show($id)
     {
         try {
-            $racket = Racket::with(['maker', 'racketImages'])->findOrFail($id);
+            $racket = Racket::with(['maker', 'racketImage'])->findOrFail($id);
 
             return response()->json($racket, 200);
         } catch (\ModelNotFoundException $e) {

--- a/app/Models/Racket.php
+++ b/app/Models/Racket.php
@@ -22,7 +22,7 @@ class Racket extends Model
         return $this->belongsTo(Maker::class);
     }
 
-    public function racketImages()
+    public function racketImage()
     {
         return $this->belongsTo(RacketImage::class,  'image_id', 'id');
     }

--- a/app/Models/Racket.php
+++ b/app/Models/Racket.php
@@ -24,7 +24,7 @@ class Racket extends Model
 
     public function racketImages()
     {
-        return $this->hasMany(RacketImage::class, 'id', 'image_id');
+        return $this->belongsTo(RacketImage::class,  'image_id', 'id');
     }
 
     public function tennisProfiles()

--- a/app/Models/RacketImage.php
+++ b/app/Models/RacketImage.php
@@ -16,6 +16,6 @@ class RacketImage extends Model
 
     public function racket()
     {
-        return $this->belongsTo(Racket::class, 'id','image_id');
+        return $this->hasMany(Racket::class, 'image_id','id');
     }
 }

--- a/app/Models/RacketImage.php
+++ b/app/Models/RacketImage.php
@@ -14,7 +14,7 @@ class RacketImage extends Model
         'title'
     ];
 
-    public function racket()
+    public function rackets()
     {
         return $this->hasMany(Racket::class, 'image_id','id');
     }


### PR DESCRIPTION
issue: #29 

やったこと：
- racketsとracketImagesテーブルのリレーションのhasManyとbelongsToを逆に修正した
- 修正による影響箇所の変更

レビューお願いします