### PR TITLE
modify: TennisProfileUpdateRequestのmy_racket_idカラムバリデーションにnullableを追加

### DIFF
--- a/app/Http/Requests/TennisProfile/TennisProfileUpdateRequest.php
+++ b/app/Http/Requests/TennisProfile/TennisProfileUpdateRequest.php
@@ -25,7 +25,7 @@ class TennisProfileUpdateRequest extends FormRequest
     {
         return [
             'gender'            => ['required', 'string', 'max:15'],
-            'my_racket_id'      => ['sometimes', 'integer', 'exists:rackets,id'],
+            'my_racket_id'      => ['nullable', 'integer', 'exists:rackets,id'],
             'grip_form'         => ['required', 'string', 'max:15'],
             'height'            => ['required', 'string', 'max:20'],
             'age'               => ['required', 'string', 'max:15'],


### PR DESCRIPTION
issue: #34 
フロントでmy_racketを選択していない場合を考慮してnullを許容するよう変更しました。

sometimesバリデーションは不要なので削除しました

レビューお願いします。