### PR TITLE
add:GutControllerにgut詳細ページのガット以外のデータを取得するgetRandamOtherGutsを実装

### DIFF
--- a/app/Http/Controllers/GutController.php
+++ b/app/Http/Controllers/GutController.php
@@ -10,10 +10,10 @@ use App\Models\Gut;
 class GutController extends Controller
 {
     public function __construct()
-    {   
+    {
         $this->middleware('auth:admin')->only(['store', 'update', 'destroy']);
     }
-    
+
     /**
      * Display a listing of the resource.
      *
@@ -134,5 +134,40 @@ class GutController extends Controller
 
             throw $e;
         }
+    }
+
+    public function getRandamOtherGuts(Request $request, $id)
+    {
+        // 取得するgutデータの数を指定
+        $count = $request->query('count');
+
+        // $otherGuts = Gut::where('id', '!=', $id)->get();
+        $otherGuts = Gut::where('id', '!=', $id)->with(['gutImage', 'maker'])->get();
+
+        // othergutsからランダムにデータを取り出すためのランダムindexの配列を生成
+        $randomIndexes = [];
+        for ($i = 0; $i < $count; $i++) {
+            while (true) {
+                // /** otherGutsの配列の中身の数を元に一時的な乱数を作成 */
+                $num = mt_rand(0, count($otherGuts) - 1);
+
+                // randomIndexesに含まれているならwhile続行、含まれてないなら配列に代入してbreak            
+                if (!in_array($num, $randomIndexes)) {
+                    array_push($randomIndexes, $num);
+                    break;
+                }
+            }
+        }
+
+        //responseGutsが整列されるようにrandomIndexesを整列
+        sort($randomIndexes, SORT_ASC);
+
+        // 生成されたrandumndexesを元に取り出したgut情報をresponseGutsにそれぞれ格納
+        $responseGuts = [];
+        foreach ($randomIndexes as $index) {
+            array_push($responseGuts, $otherGuts[$index]);
+        }
+
+        return response()->json($responseGuts, 200);
     }
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -40,6 +40,7 @@ Route::apiResource('api/gut_images', GutImageController::class);
 Route::apiResource('api/racket_images', RacketImageController::class);
 
 Route::apiResource('api/guts', GutController::class);
+Route::get('api/guts/{id}/others', [GutController::class, 'getRandamOtherGuts']);
 
 Route::apiResource('api/rackets', RacketController::class);
 


### PR DESCRIPTION
やったこと：
- otherGutsとしてランダムにqueryのcountで指定された個数を返すようにした
- 指定されたgut以外のguts情報を取得
- 取得した配列の中身の個数を元にランダムなindex番号の配列を生成
- そのランダムなindexの配列を使ってqueryで送られてきたcountで指定された個数をレスポンスとして返却


レビューお願いします