### PR TITLE
add: user パスワード変更api

### DIFF
--- a/app/Http/Controllers/User/Auth/PasswordController.php
+++ b/app/Http/Controllers/User/Auth/PasswordController.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Controllers\User\Auth;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Validation\Rules\Password;
+
+class PasswordController extends Controller
+{
+    public function update(Request $request): JsonResponse
+    {
+        $validated = $request->validateWithBag('updatePassword', [
+            'current_password' => ['required', 'current_password'],
+            'password' => ['required', Password::defaults(), 'confirmed'],
+        ]);
+
+        try {
+            $request->user()->update([
+                'password' => Hash::make($validated['password']),
+            ]);
+    
+            return response()->json('パスワードを変更しました', 200);
+        } catch (\Throwable $e) {
+            \Log::error($e);
+
+            throw $e;
+        }
+    }
+}

--- a/routes/auth.php
+++ b/routes/auth.php
@@ -6,7 +6,8 @@ use App\Http\Controllers\User\Auth\NewPasswordController;
 use App\Http\Controllers\User\Auth\PasswordResetLinkController;
 use App\Http\Controllers\User\Auth\RegisteredUserController;
 use App\Http\Controllers\User\Auth\VerifyEmailController;
-use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\User\Auth\PasswordController;
+use Illuminate\Support\Facades\Route; 
 
 
 Route::post('/register', [RegisteredUserController::class, 'store'])
@@ -36,3 +37,7 @@ Route::post('/email/verification-notification', [EmailVerificationNotificationCo
 Route::post('/logout', [AuthenticatedSessionController::class, 'destroy'])
                 ->middleware('auth:user')
                 ->name('logout');
+
+Route::put('/password-update', [PasswordController::class, 'update'])
+                ->middleware('auth:user')
+                ->name('passowrd-update');


### PR DESCRIPTION
背景：
laravel breezeの api オブションで認証を作成するとpassword更新処理機能は実装されていないので実装する。

やったこと：
- passowrdControllerを作成しupdateメソッド内で更新処理を記載


レビューお願いします
