### PR TITLE
add: gut_image検索機能の実装

### DIFF
--- a/app/Http/Controllers/GutImageController.php
+++ b/app/Http/Controllers/GutImageController.php
@@ -173,4 +173,45 @@ class GutImageController extends Controller
             throw $e;
         }
     }
+
+    public function gutImageSearch(Request $request)
+    {
+        $severalWords = $request->query('several_words');
+
+        if ($severalWords) {
+            //全角スペースを半角に変換
+            $spaceConversion = mb_convert_kana($severalWords, 's');
+
+            // 単語を半角スペースで区切り、配列にする（例："山田 翔" → ["山田", "翔"]）
+            $severalWordsArray = preg_split('/[\s,]+/', $spaceConversion, -1, PREG_SPLIT_NO_EMPTY);
+        }
+
+        $maker_id = $request->query('maker');
+
+        $gutImageQuery = GutImage::query();
+
+        if ($severalWords && $maker_id) {
+            foreach ($severalWordsArray as $word) {
+                //severalWordsで複数取れてきてもmakerが一致しない場合は弾かれる
+                $gutImageQuery
+                    ->orWhere(function ($gutImageQuery) use ($word, $maker_id) {
+                        $gutImageQuery
+                            ->where('title', 'like', '%' . $word . '%')
+                            ->where('maker_id', '=', $maker_id);
+                    });
+            }
+        } elseif ($severalWords && empty($maker_id)) {
+            //makerの指定がないのでseveralWordsのor検索となる
+            foreach ($severalWordsArray as $word) {
+                $gutImageQuery->orWhere('title', 'like', '%' . $word . '%');
+            }
+        } elseif (empty($severalWords) && $maker_id) {
+            //makerのみでの検索
+            $gutImageQuery->where('maker_id', '=', $maker_id);
+        }
+
+        $searchedGutImages = $gutImageQuery->get();
+
+        return response()->json($searchedGutImages, 200);
+    }
 }

--- a/database/migrations/2023_12_08_195311_add_column_maker_id_to_gut_images_table.php
+++ b/database/migrations/2023_12_08_195311_add_column_maker_id_to_gut_images_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('gut_images', function (Blueprint $table) {
+            $table->foreignId('maker_id')->nullable()->constrained('makers');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('gut_images', function (Blueprint $table) {
+            $table->dropForeign('gut_images_maker_id_foreign');
+            $table->dropColumn('maker_id');
+        });
+    }
+};

--- a/database/seeders/GutImageSeeder.php
+++ b/database/seeders/GutImageSeeder.php
@@ -21,12 +21,14 @@ class GutImageSeeder extends Seeder
             [
                 'file_path' => 'images/guts/sample_image1.png',
                 'title' => 'ポリツアープロ',
+                'maker_id' => 1,
                 'created_at' => Carbon::now(),
                 'updated_at' => Carbon::now()
             ],
             [
                 'file_path' => 'images/guts/sample_image2.jpg',
                 'title' => 'ポリツアープロ',
+                'maker_id' => 1,
                 'created_at' => Carbon::now(),
                 'updated_at' => Carbon::now()
             ],

--- a/routes/web.php
+++ b/routes/web.php
@@ -35,6 +35,7 @@ Route::get('/', function () {
 
 Route::middleware('auth:admin')->apiResource('api/makers', MakerController::class);
 
+Route::get('api/gut_images/search', [GutImageController::class, 'gutImageSearch']);
 Route::apiResource('api/gut_images', GutImageController::class);
 
 Route::apiResource('api/racket_images', RacketImageController::class);


### PR DESCRIPTION
issue: #58 

背景:
フロントでストリングを新規登録・更新するとき画像を設定するようになっており、そこでの検索apiが必要になった。

やったこと；
- makerで検索できるようにgut_imagesテーブルに新たにmakersテーブルに紐ついたmaker_idカラムを追加
- title,　makerで検索できる機能の実装
    - title,maker両方で検索された時と、どちらか一方の検索の時で場合分けして記述した

レビューお願いします