### PR TITLE
modify: gutImage検索機能の検索結果にmaker情報をeagerloadingで合わせて返却するようにした

### DIFF
--- a/app/Http/Controllers/GutImageController.php
+++ b/app/Http/Controllers/GutImageController.php
@@ -210,7 +210,7 @@ class GutImageController extends Controller
             $gutImageQuery->where('maker_id', '=', $maker_id);
         }
 
-        $searchedGutImages = $gutImageQuery->get();
+        $searchedGutImages = $gutImageQuery->with('maker')->get();
 
         return response()->json($searchedGutImages, 200);
     }

--- a/app/Models/GutImage.php
+++ b/app/Models/GutImage.php
@@ -17,4 +17,8 @@ class GutImage extends Model
     public function guts() {
         return $this->hasMany(Gut::class, 'image_id', 'id');
     }
+
+    public function maker() {
+        return $this->belongsTo(Maker::class);
+    }
 }

--- a/app/Models/Maker.php
+++ b/app/Models/Maker.php
@@ -22,4 +22,9 @@ class Maker extends Model
     {
         return $this->hasMany(Racket::class);
     }
+
+    public function gutImages()
+    {
+        return $this->hasMany(GutImage::class);
+    }
 }


### PR DESCRIPTION
issue: #60 

やったこと：
- GutImageモデルとMakerモデルにリレーションに関するメソッドを追加
- GutImageControllerのgutImageSearchメソッドの返却データを整理するところでwithメソッドによってmaker情報を一緒に返却するようにした

レビューお願いします