### PR TITLE
modify: gut_imagesテーブルのfile_pathカラムのユニーク制約を取り除いた

### DIFF
--- a/database/migrations/2023_12_09_173101_remove_unique_constraint_from_gut_images_table.php
+++ b/database/migrations/2023_12_09_173101_remove_unique_constraint_from_gut_images_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('gut_images', function (Blueprint $table) {
+            $table->dropUnique('gut_images_file_path_unique');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('gut_images', function (Blueprint $table) {
+            $table->unique('file_path');
+        });
+    }
+};


### PR DESCRIPTION
issue: #62 

**_現状：_**
file_pathカラムにユニーク制約がついているためdefault画像など初期の画像を複数のgutのイメージとして利用できない状態であった

**_やったこと_**
- file_pathカラムからユニーク制約を取り除くmigrationファイルを作成実行

レビューお願いします。

