### PR TITLE
modify: Gut登録時リクエストのimage_idがnullの時にデフォルトイメージを登録するように変更

### DIFF
--- a/app/Http/Controllers/GutController.php
+++ b/app/Http/Controllers/GutController.php
@@ -6,6 +6,7 @@ use App\Http\Requests\Gut\GutStoreRequest;
 use App\Http\Requests\Gut\GutUpdateRequest;
 use Illuminate\Http\Request;
 use App\Models\Gut;
+use App\Models\GutImage;
 
 class GutController extends Controller
 {
@@ -42,12 +43,16 @@ class GutController extends Controller
     {
         $validated = $request->validated();
 
+        if(empty($validated['image_id'])) {
+            $defaultgutImage = GutImage::where('file_path', '=', 'images/guts/default_gut_image.jpg')->get()[0];
+        }
+
         try {
             $gut = Gut::create([
                 'name_ja' => $validated['name_ja'],
                 'name_en' => $validated['name_en'],
                 'maker_id' => $validated['maker_id'],
-                'image_id' => isset($validated['image_id']) ? $validated['image_id'] : null,
+                'image_id' => isset($validated['image_id']) ? $validated['image_id'] : $defaultgutImage->id,
                 'need_posting_image' => $validated['need_posting_image'],
             ]);
 
@@ -92,6 +97,8 @@ class GutController extends Controller
     public function update(GutUpdateRequest $request, $id)
     {
         $validated = $request->validated();
+
+        
 
         try {
             $gut = Gut::findOrFail($id);


### PR DESCRIPTION
issue: #67 

現状：
image_idをnullで登録するとフロントで表示させる時にエラーとなっている

再現手順：
- postmanやフロントでimageを選択しない（null）の状態で登録しようとする
- gut一覧ページなど登録した情報を表示するページに遷移した時にえらーとなる

やったこと：
GutControllerのstoreメソッドでリクエストのimage_idがnullの場合にデフォルトのgut_imageをgut_imagesテーブルから取得し、それをgutのimage_idとして登録するようにしました

レビューお願いします
