### PR TITLE
add: racket_image検索APIの実装

### DIFF
--- a/app/Models/Maker.php
+++ b/app/Models/Maker.php
@@ -27,4 +27,9 @@ class Maker extends Model
     {
         return $this->hasMany(GutImage::class);
     }
+
+    public function racketImages()
+    {
+        return $this->hasMany(RacketImage::class);
+    }
 }

--- a/app/Models/RacketImage.php
+++ b/app/Models/RacketImage.php
@@ -18,4 +18,9 @@ class RacketImage extends Model
     {
         return $this->hasMany(Racket::class, 'image_id','id');
     }
+
+    public function maker()
+    {
+        return $this->belongsTo(Maker::class);
+    }
 }

--- a/database/migrations/2023_12_12_181539_add_column_maker_id_to_racket_images_table.php
+++ b/database/migrations/2023_12_12_181539_add_column_maker_id_to_racket_images_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('racket_images', function (Blueprint $table) {
+            $table->foreignId('maker_id')->nullable()->constrained('makers');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('racket_images', function (Blueprint $table) {
+            $table->dropForeign('racket_images_maker_id_foreign');
+            $table->dropColumn('maker_id');
+        });
+    }
+};

--- a/database/seeders/MakerSeeder.php
+++ b/database/seeders/MakerSeeder.php
@@ -18,6 +18,12 @@ class MakerSeeder extends Seeder
     {
         DB::table('makers')->insert([
             [
+                'name_ja' => 'その他',
+                'name_en' => 'others',
+                'created_at' => Carbon::now(),
+                'updated_at' => Carbon::now(),
+            ],
+            [
                 'name_ja' => 'ヨネックス',
                 'name_en' => 'yonex',
                 'created_at' => Carbon::now(),

--- a/database/seeders/RacketImageSeeder.php
+++ b/database/seeders/RacketImageSeeder.php
@@ -18,14 +18,58 @@ class RacketImageSeeder extends Seeder
     {
         DB::table('racket_images')->insert([
             [
-                'file_path' => 'images/rackets/sample_racket_image1.png',
-                'title' => 'プロスタッフ',
+                'file_path' => 'images/rackets/default_racket_image.png',
+                'title' => 'デフォルトラケットイメージ',
+                'maker_id' => 1,
                 'created_at' => Carbon::now(),
                 'updated_at' => Carbon::now()
             ],
             [
-                'file_path' => 'images/rackets/sample_racket_image2.jpg',
+                'file_path' => 'images/rackets/default_racket_image1.jpg',
                 'title' => 'ピュアアエロ',
+                'maker_id' => 3,
+                'created_at' => Carbon::now(),
+                'updated_at' => Carbon::now()
+            ],
+            [
+                'file_path' => 'images/rackets/default_racket_image2.jpg',
+                'title' => 'ブレード',
+                'maker_id' => 4,
+                'created_at' => Carbon::now(),
+                'updated_at' => Carbon::now()
+            ],
+            [
+                'file_path' => 'images/rackets/default_racket_image3.jpg',
+                'title' => 'プロスタッフ',
+                'maker_id' => 4,
+                'created_at' => Carbon::now(),
+                'updated_at' => Carbon::now()
+            ],
+            [
+                'file_path' => 'images/rackets/default_racket_image4.jpg',
+                'title' => 'v コア100',
+                'maker_id' => 2,
+                'created_at' => Carbon::now(),
+                'updated_at' => Carbon::now()
+            ],
+            [
+                'file_path' => 'images/rackets/default_racket_image5.jpg',
+                'title' => 'スピード',
+                'maker_id' => 5,
+                'created_at' => Carbon::now(),
+                'updated_at' => Carbon::now()
+            ],
+            [
+                'file_path' => 'images/rackets/default_racket_image6.jpg',
+                'title' => 'o3',
+                'maker_id' => 6,
+                'created_at' => Carbon::now(),
+                'updated_at' => Carbon::now()
+            ],
+            [
+                'file_path' => 'images/rackets/default_racket_image7.jpg',
+                'title' => 'ピュアドライブ',
+                'maker_id' => 3,
                 'created_at' => Carbon::now(),
                 'updated_at' => Carbon::now()
             ],

--- a/routes/web.php
+++ b/routes/web.php
@@ -38,6 +38,7 @@ Route::middleware('auth:admin')->apiResource('api/makers', MakerController::clas
 Route::get('api/gut_images/search', [GutImageController::class, 'gutImageSearch']);
 Route::apiResource('api/gut_images', GutImageController::class);
 
+Route::get('api/racket_images/search', [RacketImageController::class, 'racketImageSearch']);
 Route::apiResource('api/racket_images', RacketImageController::class);
 
 Route::get('api/guts/search', [GutController::class, 'gutSearch']);


### PR DESCRIPTION
issue: #69 

やったこと：
- racket_imagesテーブルにmakersテーブルと紐つくmaker_idを追加するmigrationファイルを記載・実行
- MakerSeederにて、その他のメーカー追加
- RacketImageSeederにて、maker_idを追加したデータを複数レコード用意
- makersテーブルとracket_imagesテーブルのリレーション関係を各Modelファイルに記載していなかったので記載
- RacketImageContorollerにracketImageSearchメソッドを作成
- 

レビューお願いします。