### PR TITLE
modify:#71:　makerの一覧取得indexメソッドをuserでも使えるように修正

### DIFF
--- a/app/Http/Controllers/MakerController.php
+++ b/app/Http/Controllers/MakerController.php
@@ -9,6 +9,11 @@ use App\Http\Requests\Maker\MakerUpdateRequest;
 
 class MakerController extends Controller
 {
+    public function __construct()
+    {
+        $this->middleware('auth:admin')->only(['show', 'store', 'update', 'destroy']);
+    }
+    
     public function index()
     {
         try {

--- a/routes/web.php
+++ b/routes/web.php
@@ -33,7 +33,7 @@ Route::get('/', function () {
 // require __DIR__.'/user/api.php';
 
 
-Route::middleware('auth:admin')->apiResource('api/makers', MakerController::class);
+Route::apiResource('api/makers', MakerController::class);
 
 Route::get('api/gut_images/search', [GutImageController::class, 'gutImageSearch']);
 Route::apiResource('api/gut_images', GutImageController::class);


### PR DESCRIPTION
issue: #71 

やたこと：
- routingミドルウェアでauth:adminを指定していたところをコントローラーミドルウェアでindex以外にauth:adminを指定して、maker一覧情報取得のindexメソッドはuser権限でも使えるようにした

レビューお願いします。
