### PR TITLE
add: RacketControllerでpagination用のデータを返却されるように修正

### DIFF
--- a/app/Http/Controllers/RacketController.php
+++ b/app/Http/Controllers/RacketController.php
@@ -23,7 +23,7 @@ class RacketController extends Controller
     public function index()
     {
         try {
-            $rackets = Racket::with(['maker', 'racketImage'])->get();
+            $rackets = Racket::with(['maker', 'racketImage'])->paginate(8);
 
             return response()->json($rackets, 200);
         } catch (\Throwable $e) {
@@ -216,7 +216,10 @@ class RacketController extends Controller
             $racketQuery->where('maker_id', '=', $maker_id);
         }
 
-        $searchedRackets = $racketQuery->with(['maker', 'racketImage'])->get();
+        $searchedRackets = $racketQuery
+            ->with(['maker', 'racketImage'])
+            ->paginate(8)
+            ->appends(['several_words' => $severalWords, 'maker' => $maker_id]);
 
         return response()->json($searchedRackets, 200);
     }


### PR DESCRIPTION
_**issue:**_ #75 

_**背景:**_
indexメソッド、gutSearchメソッドで返却されるデータはpagination用のデータではなく、フロントで表示させる時に一画面に全てのデータを表示させることになっていたので不便であった

_**やったこと：**_

- [ ] RacketControllerのindexメソッドでのデータ取得でpaginateメソッドを使用してpagination用のメタデータを返却するように変更
- [ ] 同じくgutSearchメソッドでpaginateメソッドで書き換え

_**備考：**_
gutSearchメソッドでメタデータとして返却される2ページ目以降のurlに検索用のqueryが付与されていないものが返却されており、フロント側で検索結果のページネーションの二ページ目以降が正しく表示されなていなかったため、appendsメソッドを使って検索用のqueryがurlに付与されるようにしてあります。

レビューお願いします

racketSearchメソッドでは検索項目queryをpaginate返却データの各urlの付与されるように実装