### PR TITLE
modify: 検索結果に対するページネーションの不具合の修正

### DIFF
--- a/app/Http/Controllers/GutController.php
+++ b/app/Http/Controllers/GutController.php
@@ -220,7 +220,10 @@ class GutController extends Controller
             $gutQuery->where('maker_id', '=', $maker_id);
         }
 
-        $searchedGuts = $gutQuery->with(['maker', 'gutImage'])->paginate(8);
+        $searchedGuts = $gutQuery
+            ->with(['maker', 'gutImage'])
+            ->paginate(8)
+            ->appends(['several_words' => $severalWords, 'maker' => $maker_id]);
 
         return response()->json($searchedGuts, 200);
     }


### PR DESCRIPTION
_**issue:**_ #76 

_**背景：**_
以前GutControllerにpaginateメソッドでページネーション用のメタデータを返却するように実装したがgutSearchメソッドで返却するメタデータで二ページ目以降のurlに検索項目のqueryが付与されていなかったため、フロント側で検索結果に対する二ページ目以降のリンクをクリックすると検索がかかっていない状態の２ページ目以降が表示されてしまっていた。

_**やったこと：**_

- [ ] gutSearchメソッドのpaginateメソッドを使っている部分でappendsメソッドを使って検索項目のqueryをurlに含めるように変更した

レビューお願いします