### PR TITLE
modify: RacktImageControllerでmaker_idカラムの登録に対応するように書くメソッドを修正

### DIFF
--- a/app/Http/Requests/RacketImage/RacketImageStoreRequest.php
+++ b/app/Http/Requests/RacketImage/RacketImageStoreRequest.php
@@ -25,7 +25,8 @@ class RacketImageStoreRequest extends FormRequest
     {
         return [
             'file' => ['required', 'file', 'image', 'mimes:jpeg,png'],
-            'title' => ['required', 'max:30']
+            'title' => ['required', 'max:30'],
+            'maker_id' => ['required', 'integer', 'exists:makers,id'],
         ];
     }
 }

--- a/app/Http/Requests/RacketImage/RacketImageUpdateRequest.php
+++ b/app/Http/Requests/RacketImage/RacketImageUpdateRequest.php
@@ -25,7 +25,8 @@ class RacketImageUpdateRequest extends FormRequest
     {
         return [
             'file' => ['file', 'image', 'mimes:jpeg,png'],
-            'title' => ['max:30']
+            'title' => ['max:30'],
+            'maker_id' => ['required', 'integer', 'exists:makers,id'],
         ];
     }
 }

--- a/app/Models/RacketImage.php
+++ b/app/Models/RacketImage.php
@@ -11,7 +11,8 @@ class RacketImage extends Model
 
     protected $fillable = [
         'file_path',
-        'title'
+        'title',
+        'maker_id'
     ];
 
     public function rackets()


### PR DESCRIPTION
_**issue:**_ #79 

_**背景：**_
racket_imagesテーブルにmaker_idカラムを追加してありseederのダミーデータもmake_idありのデータに修正してあったが、RacketImageControllerでmaker_idカラムに対応したコードに修正しておらず対応させる必要があった。

_**やったこと：**_

- [ ] storeメソッドでmaker_idを考慮した登録処理コードに修正
- [ ] updateメソッドでmaker_idを考慮したコードに修正
- [ ] index, showメソッドでmaker_idによるmaker情報も返却するように修正
- [ ] racketImageのモデルとRequestに関するファイルをmaker_idを考慮したものに修正

レビューお願いします