### PR TITLE
modify:#81:GutImageControllerで各メソッドをmaker_idカラムを考慮したものに修正

### DIFF
--- a/app/Http/Requests/GutImage/GutImageStoreRequest.php
+++ b/app/Http/Requests/GutImage/GutImageStoreRequest.php
@@ -25,7 +25,8 @@ class GutImageStoreRequest extends FormRequest
     {
         return [
             'file' => ['required', 'file', 'image', 'mimes:jpeg,png'],
-            'title' => ['required', 'max:30']
+            'title' => ['required', 'max:30'],
+            'maker_id' => ['required', 'integer', 'exists:makers,id'],
         ];
     }
 }

--- a/app/Http/Requests/GutImage/GutImageUpdateRequest.php
+++ b/app/Http/Requests/GutImage/GutImageUpdateRequest.php
@@ -25,7 +25,8 @@ class GutImageUpdateRequest extends FormRequest
     {
         return [
             'file' => ['file', 'image', 'mimes:jpeg,png'],
-            'title' => ['max:30']
+            'title' => ['max:30'],
+            'maker_id' => ['required', 'integer', 'exists:makers,id'],
         ];
     }
 }

--- a/app/Models/GutImage.php
+++ b/app/Models/GutImage.php
@@ -11,7 +11,8 @@ class GutImage extends Model
 
     protected $fillable = [
         'file_path',
-        'title'
+        'title',
+        'maker_id'
     ];
 
     public function guts() {


### PR DESCRIPTION
_**issue:**_ #81 

_**背景：**_
gut_imagesテーブルにmaker_idカラムを後から追加していたがGutImageControllerの各メソッドでmaker_idカラムを考慮した処理の記述となっていなかった

_**やったこと：**_

- [ ] indexメソッドをmaker_idカラムを考慮したものに修正
- [ ] showメソッドをmaker_idカラムを考慮したものに修正
- [ ] storeメソッドをmaker_idカラムを考慮したものに修正
- [ ] updateメソッドをmaker_idカラムを考慮したものに修正
- [ ] modelとRequestファイルをmaker_idを考慮したものに修正

レビューお願いします