### PR TITLE
add: TennisProfileControllerにログイン中ユーザーに紐つくtennisProfile情報を取得するメソッドを追加

### DIFF
--- a/app/Http/Controllers/TennisProfileController.php
+++ b/app/Http/Controllers/TennisProfileController.php
@@ -144,4 +144,24 @@ class TennisProfileController extends Controller
     {
         //
     }
+
+    public function getCurrentUserTennisProfile($userId)
+    {
+        try {
+            $tennis_profile = TennisProfile::where('user_id', '=', $userId)
+                ->with([
+                    'user',
+                    'racket' => ['maker', 'racketImage']
+                ])
+                ->get()[0];
+
+            return response()->json($tennis_profile, 200);
+        } catch (\ModelNotFoundException $e) {
+            throw $e;
+        } catch (\Throwable $e) {
+            \Log::error($e);
+
+            throw $e;
+        }
+    }
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -50,6 +50,7 @@ Route::apiResource('api/rackets', RacketController::class);
 Route::get('api/rackets/{id}/others', [RacketController::class, 'getRandamOtherRackets']);
 
 Route::apiResource('api/tennis_profiles', TennisProfileController::class);
+Route::get('api/tennis_profiles/user/{userId}', [TennisProfileController::class, 'getCurrentUserTennisProfile']);
 
 Route::apiResource('api/my_equipments', MyEquipmentController::class);
 Route::get('/api/my_equipments/user/{id}', [ MyEquipmentController::class, 'getAllEquipmentOfUser']);


### PR DESCRIPTION
issue: #84 

背景：
フロントでログイン中ユーザーに紐つくtennisProfile情報を利用したかったが、ログインユーザーに紐つくtennisProfileを取得するapiがなかったためそれができなかった

やったこと：

- [ ] ログイン中のユーザーのidを受けてtennisProfileを取得するメソッドをTennisProfileControllerに作成した。
- [ ] メソッドを追加したことによりそれに伴うルーティングも設定した

レビューお願いします