### PR TITLE
modify: GutImageController, RacketImageControllerのデータ取得をページネーションに対応したものに修正した

### DIFF
--- a/app/Http/Controllers/GutImageController.php
+++ b/app/Http/Controllers/GutImageController.php
@@ -25,23 +25,9 @@ class GutImageController extends Controller
     public function index()
     {
         try {
-            $gut_images = GutImage::with('maker')->get();
+            $gut_images = GutImage::with('maker')->paginate(8);
 
-            $image_infos = [];
-
-            //各imageのpathを整形して返却
-            foreach ($gut_images as $image) {
-                $image_info = [
-                    'id' => $image->id,
-                    'title' => $image->title,
-                    'file_path' => Storage::url($image->file_path),
-                    'maker' => $image->maker
-                ];
-
-                array_push($image_infos, $image_info);
-            }
-
-            return response()->json($image_infos, 200);
+            return response()->json($gut_images, 200);
         } catch (\Throwable $e) {
             \Log::error($e);
 
@@ -223,7 +209,10 @@ class GutImageController extends Controller
             $gutImageQuery->where('maker_id', '=', $maker_id);
         }
 
-        $searchedGutImages = $gutImageQuery->with('maker')->get();
+        $searchedGutImages = $gutImageQuery
+            ->with('maker')
+            ->paginate(8)
+            ->appends(['several_words' => $severalWords, 'maker' => $maker_id]);
 
         return response()->json($searchedGutImages, 200);
     }

--- a/app/Http/Controllers/RacketImageController.php
+++ b/app/Http/Controllers/RacketImageController.php
@@ -24,24 +24,9 @@ class RacketImageController extends Controller
     public function index()
     {
         try {
-            // $racket_images = RacketImage::with('maker')->all();
-            $racket_images = RacketImage::with('maker')->get();
+            $racket_images = RacketImage::with('maker')->paginate(8);
 
-            $image_infos = [];
-
-            //各imageのpathを整形して返却
-            foreach ($racket_images as $image) {
-                $image_info = [
-                    'id' => $image->id,
-                    'title' => $image->title,
-                    'file_path' => Storage::url($image->file_path),
-                    'maker' => $image->maker
-                ];
-
-                array_push($image_infos, $image_info);
-            }
-
-            return response()->json($image_infos, 200);
+            return response()->json($racket_images, 200);
         } catch (\Throwable $e) {
             \Log::error($e);
 
@@ -221,7 +206,10 @@ class RacketImageController extends Controller
             $racketImageQuery->where('maker_id', '=', $maker_id);
         }
 
-        $searchedRacketImages = $racketImageQuery->with('maker')->get();
+        $searchedRacketImages = $racketImageQuery
+            ->with('maker')
+            ->paginate(8)
+            ->appends(['several_words' => $severalWords, 'maker' => $maker_id]);
 
         return response()->json($searchedRacketImages, 200);
     }


### PR DESCRIPTION
_**issue:**_ #87 

_**背景：**_
indexメソッドgutImageSearchメソッドどちらもqueryもしくはeloquentの最後でget()メソッドで取得しており、ページネーションに対応したデータ取得をしていない

_**確認手順：**_
postmanで確認

- [ ] GutImageGetAllApiリクエストを送るとそのまま一覧情報が取得され、ページネーションに対応していないことがわかる
- [ ] gutImageSearchApiリクエストを送ると検索結果がそのまま一覧として取得されページネーションに対応していないことが確認できる
- [ ] GutImageControllerのindexメソッドとgutImageSearchメソッドでgetメソッドでデータを取ってきていることが確認できる

_**やったこと：**_

- [ ] GutImageControllerのindexメソッド、gutImageSearchメソッドでデータの取得をpagenateメソッドで実行するように修正。
- [ ] 加えて、gutImageSearchメソッドではpaginateメソッドの後にappendsメソッドでフロントに返却されるpaginateメタデータ内のurlに検索項目がqueryで含まれるようにしている。
- [ ] RacketImageControllerのindexメソッド、racketImageSearchメソッドでデータの取得をpagenateメソッドで実行するように修正。
- [ ] 加えて、racketImageSearchメソッドではpaginateメソッドの後にappendsメソッドでフロントに返却されるpaginateメタデータ内のurlに検索項目がqueryで含まれるようにしている。

_**備考：**_
paginateメソッドの後にappendsメソッドで検索項目をqueryに含めるようにしないで、paginateメソッドのみでデータを取得返却しようとすると、paginateリンクのurlにqueryに検索項目が付与されず、二ページ目以降のページネーション先が検索をかけていないデータを取ってきてしまうためである

レビューお願いします