### PR TITLE
Feature/#89/202312/ryuichi works/add user id column to gut reviews table

### DIFF
--- a/app/Http/Controllers/GutReviewController.php
+++ b/app/Http/Controllers/GutReviewController.php
@@ -6,6 +6,7 @@ use Illuminate\Http\Request;
 use App\Models\GutReview;
 use App\Http\Requests\GutReview\GutReviewStoreRequest;
 use App\Http\Requests\GutReview\GutReviewUpdateRequest;
+use Illuminate\Support\Facades\Auth;
 
 class GutReviewController extends Controller
 {
@@ -44,8 +45,11 @@ class GutReviewController extends Controller
     {
         $validated = $request->validated();
 
+        $userId = Auth::guard('user')->id();
+
         try {
             $gut_review = GutReview::create([
+                'user_id' => $userId,
                 'equipment_id' => $validated['equipment_id'],
                 'match_rate' => $validated['match_rate'],
                 'pysical_durability' => $validated['pysical_durability'],

--- a/app/Models/GutReview.php
+++ b/app/Models/GutReview.php
@@ -10,6 +10,7 @@ class GutReview extends Model
     use HasFactory;
 
     protected $fillable = [
+        'user_id',
         'equipment_id',
         'match_rate',
         'pysical_durability',

--- a/app/Models/GutReview.php
+++ b/app/Models/GutReview.php
@@ -21,4 +21,9 @@ class GutReview extends Model
     {
         return $this->belongsTo(MyEquipment::class,'equipment_id', 'id');
     }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -52,4 +52,9 @@ class User extends Authenticatable
     {
         return $this->hasMany(MyEquipment::class);
     }
+
+    public function gutReviews()
+    {
+        return $this->hasMany(GutReview::class);
+    }
 }

--- a/database/migrations/2024_01_02_111605_add_column_user_id_to_gut_reviews_table.php
+++ b/database/migrations/2024_01_02_111605_add_column_user_id_to_gut_reviews_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('gut_reviews', function (Blueprint $table) {
+            $table->foreignId('user_id')->after('id')->constrained('users');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('gut_reviews', function (Blueprint $table) {
+            $table->dropForeign('gut_reviews_user_id_foreign');
+            $table->dropColumn('user_id');
+        });
+    }
+};


### PR DESCRIPTION
issue: #89 

背景：
gut_reviewsテーブルにはuser_idカラムがなく、user情報の参照はgut_reviewに紐つくmy_equipmentsテーブルのuser_idカラムを参照するしかなく、検索機能などの実装でコードが複雑になる恐れがあることと、今後gut_reviewsテーブルの情報を扱いやすくしたい

やったこと：
- [ ] gut_reviewsテーブルにuser_idカラムを追加する
- [ ] gut_reviewsテーブルとusersテーブルのリレーションをmodelファイルに追記
- [ ] 追加による影響範囲のコードの修正をする
    - [ ] GutReviewControllerのstoreメソッドを修正する
- [ ] テーブル設計書、er図を修正する

備考：
GutReviewControllerのindex, showメソッドでデータを取ってくる際にeager loadingで関連データも取ってきているが現状user情報をmy_equipmentテーブルのuser_idで情報を取ってきており、今回gut_reviewsテーブルに追加したuser_idでは関連データをとてきていない。修正しなかった理由としてはフロント側での型の影響でエラーとなってしまう恐れがあったためeager loadingに関しては修正していない。

レビューお願いします

