### PR TITLE
add: gut_review検索機能を実装

### DIFF
--- a/app/Http/Controllers/GutReviewController.php
+++ b/app/Http/Controllers/GutReviewController.php
@@ -147,6 +147,40 @@ class GutReviewController extends Controller
 
     public function gutReviewSearch(Request $request)
     {
-        return '接続確認';
+
+        try {
+            $match_rate = (int) $request->query('match_rate');
+            $pysical_durability = (int) $request->query('pysical_durability');
+            $performance_durability = (int) $request->query('performance_durability');
+
+            $search_range_type = $request->query('search_range_type');
+
+            if ($search_range_type === 'or_more') {
+                $range_type = '>=';
+            } elseif ($search_range_type === 'or_less') {
+                $range_type = '<=';
+            }
+
+            $gutReviewQuery = GutReview::query();
+
+            // gutReviewのレビュー項目での検索
+            if($match_rate && $range_type) {
+                $gutReviewQuery->where('match_rate', $range_type, $match_rate);
+            }
+
+            if($pysical_durability && $range_type) {
+                $gutReviewQuery->where('pysical_durability', $range_type, $pysical_durability);
+            }
+
+            if($performance_durability && $range_type) {
+                $gutReviewQuery->where('performance_durability', $range_type, $performance_durability);
+            }
+
+            $searchedGutReview = $gutReviewQuery->get();
+
+            return response()->json($searchedGutReview, 200);
+        } catch (\Throwable $e) {
+            throw $e;
+        }
     }
 }

--- a/app/Http/Controllers/GutReviewController.php
+++ b/app/Http/Controllers/GutReviewController.php
@@ -144,4 +144,9 @@ class GutReviewController extends Controller
             throw $e;
         }
     }
+
+    public function gutReviewSearch(Request $request)
+    {
+        return '接続確認';
+    }
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -60,6 +60,7 @@ Route::get('/api/my_equipments/user/{id}', [ MyEquipmentController::class, 'getA
 //     Route::get('api/my_equipments/user/{userId}', [ MyEquipmentController::class, 'getAllEquipmentOfUser']);
 // });
 
+Route::get('api/gut_reviews/search', [GutReviewController::class, 'gutReviewSearch']);
 Route::apiResource('api/gut_reviews', GutReviewController::class);
 
 Route::apiResource('api/users', UserController::class)->except('store');


### PR DESCRIPTION
_**issue:**_ #86 

背景：
gut_review検索機能を実装していないので実装する

_**やったこと：**_

- [ ] gut_reviewテーブルの検索項目で検索機能を実装
- [ ] my_equipmentテーブルの検索項目で検索機能を実装
- [ ] tennis_profilesテーブルの検索項目で検索機能を実装

_**備考：**_
・tennis_profilesテーブルでの検索はtennis_profileがuserに紐つくデータのためsqlのサブクエリを用いてusers,tennis_profilesテーブルを結合してからgut_reviewsテーブルとjoinするように記述してある。
・また、gutReviewSearchメソッドのコード量が多くfat controllerとなっているため後からリファクタリングの必要がある。

レビューお願いします