### PR TITLE
Feature/#92/202401/ryuichi works/modify image register func at gut and racket for capacity compression

### DIFF
--- a/app/Http/Controllers/GutImageController.php
+++ b/app/Http/Controllers/GutImageController.php
@@ -51,6 +51,7 @@ class GutImageController extends Controller
         try {
             // 画像ファイルリサイジング
             $file = Image::make($request->file('file'));
+            $file->orientate();
             $file->resize(
                 560,
                 null,

--- a/app/Http/Controllers/GutImageController.php
+++ b/app/Http/Controllers/GutImageController.php
@@ -9,6 +9,8 @@ use Illuminate\Support\Facades\Storage;
 use App\Http\Requests\GutImage\GutImageStoreRequest;
 use App\Http\Requests\GutImage\GutImageUpdateRequest;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use InterventionImage;
+use Intervention\Image\Facades\Image;
 
 class GutImageController extends Controller
 {
@@ -16,7 +18,7 @@ class GutImageController extends Controller
     {
         $this->middleware('auth:admin')->except('store');
     }
-    
+
     /**
      * Display a listing of the resource.
      *
@@ -47,17 +49,37 @@ class GutImageController extends Controller
         $validated_request = $request->validated();
 
         try {
-            $file = $request->file('file');
+            // 画像ファイルリサイジング
+            $file = Image::make($request->file('file'));
+            $file->resize(
+                560,
+                null,
+                function ($constraint) {
+                    // 縦横比を保持したままにする
+                    $constraint->aspectRatio();
+                    // 小さい画像は大きくしない
+                    $constraint->upsize();
+                }
+            );
 
             $filename = now()->format('YmdHis') . $validated_request['title'] . "." . $request->file('file')->extension();
 
-            $path = $file->storeAs('images/guts', $filename, 'public');
+            // storageに登録するためのpathを生成
+            $storagePath = storage_path('app/public/images/guts');
+            $fileLocationFullPath = $storagePath . '/' . $filename;
 
-            $gut_image = GutImage::create([
-                'file_path' => $path,
-                'title' => $validated_request['title'],
-                'maker_id' => $validated_request['maker_id']
-            ]);
+            if ($file->save($fileLocationFullPath)) {
+                // "/var/www/html/strii-backend/storage/app/public/images/guts20240105123954リサイズ確認５.jpg"
+                // intervension image導入前の登録の仕様に合わせるため
+                // 上記のようなfullPathをDBのfile_pathカラム用に整形
+                $trimedFilePath = strstr($fileLocationFullPath, 'images');
+
+                $gut_image = GutImage::create([
+                    'file_path' => $trimedFilePath,
+                    'title' => $validated_request['title'],
+                    'maker_id' => $validated_request['maker_id']
+                ]);
+            }
 
             if (isset($gut_image)) {
                 $maker = Maker::find($gut_image->maker_id);
@@ -71,7 +93,7 @@ class GutImageController extends Controller
         } catch (\Throwable $e) {
             \Log::error($e);
 
-            return $e;
+            throw $e;
         }
     }
 
@@ -116,21 +138,21 @@ class GutImageController extends Controller
             $image = GutImage::with('maker')->findOrFail($id);
 
             //新しいファイルがあれば新たにstorageに登録
-            if($request->file('file')) {
+            if ($request->file('file')) {
                 $file = $request->file('file');
                 $filename = now()->format('YmdHis') . $validated_request['title'] . "." . $request->file('file')->extension();
                 $path = $file->storeAs('images/guts', $filename, 'public');
-    
+
                 //以前のイメージファイルをstorageフォルダから削除
                 Storage::disk('public')->delete($image->file_path);
-                
+
                 $image->file_path = $path;
             }
 
             $image->title = $validated_request['title'];
             $image->maker_id = $validated_request['maker_id'];
 
-            if($image->save()) {
+            if ($image->save()) {
                 $maker = Maker::find($image->maker_id);
 
                 return response()->json([
@@ -140,7 +162,6 @@ class GutImageController extends Controller
                     'maker' => $maker
                 ], 200);
             }
-
         } catch (\Throwable $e) {
             \Log::error($e);
 

--- a/app/Http/Controllers/RacketImageController.php
+++ b/app/Http/Controllers/RacketImageController.php
@@ -8,6 +8,7 @@ use App\Models\RacketImage;
 use App\Models\Maker;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Storage;
+use Intervention\Image\Facades\Image;
 
 class RacketImageController extends Controller
 {
@@ -45,17 +46,38 @@ class RacketImageController extends Controller
         $validated_request = $request->validated();
 
         try {
-            $file = $request->file('file');
+            // 画像ファイルリサイジング
+            $file = Image::make($request->file('file'));
+            $file->orientate();
+            $file->resize(
+                480,
+                null,
+                function ($constraint) {
+                    // 縦横比を保持したままにする
+                    $constraint->aspectRatio();
+                    // 小さい画像は大きくしない
+                    $constraint->upsize();
+                }
+            );
 
             $filename = now()->format('YmdHis') . $validated_request['title'] . "." . $request->file('file')->extension();
 
-            $path = $file->storeAs('images/rackets', $filename, 'public');
+            // storageに登録するためのpathを生成
+            $storagePath = storage_path('app/public/images/rackets');
+            $fileLocationFullPath = $storagePath . '/' . $filename;
 
-            $racket_image = RacketImage::create([
-                'file_path' => $path,
-                'title' => $validated_request['title'],
-                'maker_id' => $validated_request['maker_id']
-            ]);
+            if ($file->save($fileLocationFullPath)) {
+                // "/var/www/html/strii-backend/storage/app/public/images/rackets/20240105123954リサイズ確認５.jpg"
+                // intervension image導入前の登録の仕様に合わせるため
+                // 上記のようなfullPathをDBのfile_pathカラム用に整形
+                $trimedFilePath = strstr($fileLocationFullPath, 'images');
+
+                $racket_image = RacketImage::create([
+                    'file_path' => $trimedFilePath,
+                    'title' => $validated_request['title'],
+                    'maker_id' => $validated_request['maker_id']
+                ]);
+            }
 
             if (isset($racket_image)) {
                 $maker = Maker::find($racket_image->maker_id);
@@ -69,7 +91,7 @@ class RacketImageController extends Controller
         } catch (\Throwable $e) {
             \Log::error($e);
 
-            return $e;
+            throw $e;
         }
     }
 

--- a/app/Http/Controllers/RacketImageController.php
+++ b/app/Http/Controllers/RacketImageController.php
@@ -137,14 +137,37 @@ class RacketImageController extends Controller
 
             //新しいファイルがあれば新たにstorageに登録
             if($request->file('file')) {
-                $file = $request->file('file');
+                // 画像ファイルリサイジング
+                $file = Image::make($request->file('file'));
+                $file->orientate();
+                $file->resize(
+                    480,
+                    null,
+                    function ($constraint) {
+                        // 縦横比を保持したままにする
+                        $constraint->aspectRatio();
+                        // 小さい画像は大きくしない
+                        $constraint->upsize();
+                    }
+                );
+
                 $filename = now()->format('YmdHis') . $validated_request['title'] . "." . $request->file('file')->extension();
-                $path = $file->storeAs('images/guts', $filename, 'public');
-    
-                //以前のイメージファイルをstorageフォルダから削除
-                Storage::disk('public')->delete($image->file_path);
-                
-                $image->file_path = $path;
+
+                // storageに登録するためのpathを生成
+                $storagePath = storage_path('app/public/images/rackets');
+                $fileLocationFullPath = $storagePath . '/' . $filename;
+
+                if ($file->save($fileLocationFullPath)) {
+                    // "/var/www/html/strii-backend/storage/app/public/images/rackets/20240105123954リサイズ確認５.jpg"
+                    // intervension image導入前の登録の仕様に合わせるため
+                    // 上記のようなfullPathをDBのfile_pathカラム用に整形
+                    $trimedFilePath = strstr($fileLocationFullPath, 'images');
+
+                    //以前のイメージファイルをstorageフォルダから削除
+                    Storage::disk('public')->delete($image->file_path);
+
+                    $image->file_path = $trimedFilePath;
+                }
             }
 
             $image->title = $validated_request['title'];
@@ -163,7 +186,7 @@ class RacketImageController extends Controller
         } catch (\Throwable $e) {
             \Log::error($e);
 
-            return $e;
+            throw $e;
         }
     }
 

--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,7 @@
         "php": "^8.0.2",
         "doctrine/dbal": "^3.7",
         "guzzlehttp/guzzle": "^7.2",
+        "intervention/image": "2.7.2",
         "laravel/framework": "^9.19",
         "laravel/sanctum": "^3.0",
         "laravel/tinker": "^2.7"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "deddc09de6f9f2df46013423b4564f4a",
+    "content-hash": "8bcabefec5394df1a114d43ae0186774",
     "packages": [
         {
             "name": "brick/math",
@@ -1313,6 +1313,90 @@
                 }
             ],
             "time": "2023-08-27T10:19:19+00:00"
+        },
+        {
+            "name": "intervention/image",
+            "version": "2.7.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Intervention/image.git",
+                "reference": "04be355f8d6734c826045d02a1079ad658322dad"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Intervention/image/zipball/04be355f8d6734c826045d02a1079ad658322dad",
+                "reference": "04be355f8d6734c826045d02a1079ad658322dad",
+                "shasum": ""
+            },
+            "require": {
+                "ext-fileinfo": "*",
+                "guzzlehttp/psr7": "~1.1 || ^2.0",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "~0.9.2",
+                "phpunit/phpunit": "^4.8 || ^5.7 || ^7.5.15"
+            },
+            "suggest": {
+                "ext-gd": "to use GD library based image processing.",
+                "ext-imagick": "to use Imagick based image processing.",
+                "intervention/imagecache": "Caching extension for the Intervention Image library"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.4-dev"
+                },
+                "laravel": {
+                    "providers": [
+                        "Intervention\\Image\\ImageServiceProvider"
+                    ],
+                    "aliases": {
+                        "Image": "Intervention\\Image\\Facades\\Image"
+                    }
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Intervention\\Image\\": "src/Intervention/Image"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Oliver Vogel",
+                    "email": "oliver@intervention.io",
+                    "homepage": "https://intervention.io/"
+                }
+            ],
+            "description": "Image handling and manipulation library with support for Laravel integration",
+            "homepage": "http://image.intervention.io/",
+            "keywords": [
+                "gd",
+                "image",
+                "imagick",
+                "laravel",
+                "thumbnail",
+                "watermark"
+            ],
+            "support": {
+                "issues": "https://github.com/Intervention/image/issues",
+                "source": "https://github.com/Intervention/image/tree/2.7.2"
+            },
+            "funding": [
+                {
+                    "url": "https://paypal.me/interventionio",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/Intervention",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-05-21T17:30:32+00:00"
         },
         {
             "name": "laravel/framework",

--- a/config/app.php
+++ b/config/app.php
@@ -197,6 +197,9 @@ return [
         App\Providers\EventServiceProvider::class,
         App\Providers\RouteServiceProvider::class,
 
+        // 画像加工用で追加
+        Intervention\Image\ImageServiceProvider::class,
+
     ],
 
     /*
@@ -212,6 +215,7 @@ return [
 
     'aliases' => Facade::defaultAliases()->merge([
         // 'ExampleClass' => App\Example\ExampleClass::class,
+        'InterventionImage' => Intervention\Image\Facades\Image::class,
     ])->toArray(),
 
 ];

--- a/config/image.php
+++ b/config/image.php
@@ -1,0 +1,20 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Image Driver
+    |--------------------------------------------------------------------------
+    |
+    | Intervention Image supports "GD Library" and "Imagick" to process images
+    | internally. You may choose one of them according to your PHP
+    | configuration. By default PHP's "GD Library" implementation is used.
+    |
+    | Supported: "gd", "imagick"
+    |
+    */
+
+    'driver' => 'gd'
+
+];


### PR DESCRIPTION
_**issue:**_ #92 

_**背景：**_
フロントから送られてきた画像の容量が大きいので、このままだと登録画像が増えていくとサーバーなどでの容量をすぐ超過してしまう恐れがある

_**確認手順：**_
フロントエンドから操作
- [ ] userまたはadminでログインする
- [ ] gutもしくはracket画像提供画面に遷移する
- [ ] 画像を登録する
- [ ] laravel側のフォルダのstorageの画像の容量をファインダーなどから確認する
- [ ] スマホなどで取った画像であれば4MB前後の容量となってしまっているのが確認できる。

_**やったこと：**_
gutイメージに関して
- [x] GutImageControllerの**store**メソッドにintervention imageを使って画像リサイズ、圧縮処理を追加した
- [x] GutImageControllerの**update**メソッドにintervention imageを使って画像リサイズ、圧縮処理を追加した

racketイメージに関して
- [x] RacketImageControllerの**store**メソッドにintervention imageを使って画像リサイズ、圧縮処理を追加した
- [x] RacketImageControllerの**update**メソッドにintervention imageを使って画像リサイズ、圧縮処理を追加した

_**備考：**_
intervention imageを導入する際にdockerfileを編集している。
具体的にはgd, exifなどをapt-getのところに追記している。
詳しくは
https://ketukara.com/programing/2034/
https://poppotennis.com/posts/docker-intervention-image
https://qiita.com/njn0te/items/1807c0ef2c0cbc94a305

また、intervention imageは実装時最新は3系であったが、**3系**になって間もなかったことと情報の少なさから、**2系**を使って実装している。
3系で実装する場合に参考になるサイトを残しておく
https://qiita.com/blue32a/items/e3549e1394a8b8580318

_**その他参考にしたサイト：**_
https://tech.amefure.com/php-laravel-Intervention-Image

レビューお願いします