### PR TITLE
modify:MyEquipmentControllerのindex,getAllEquipmentOfUserメソッドにページネーションを追加

### DIFF
--- a/app/Http/Controllers/MyEquipmentController.php
+++ b/app/Http/Controllers/MyEquipmentController.php
@@ -23,7 +23,7 @@ class MyEquipmentController extends Controller
     public function index()
     {
         try {
-            $my_equipment = MyEquipment::with(['user', 'mainGut', 'crossGut'])->get();
+            $my_equipment = MyEquipment::with(['user', 'mainGut', 'crossGut'])->paginate(8);
 
             return response()->json($my_equipment, 200);
         } catch (\Throwable $e) {
@@ -176,8 +176,7 @@ class MyEquipmentController extends Controller
                 'racket' => ['maker', 'racketImage'],
                 'mainGut' => ['maker', 'gutImage'],
                 'crossGut' => ['maker', 'gutImage']
-            ])->get();
-            // $user_equipments = MyEquipment::where('user_id', '=', $id)->get();
+            ])->paginate(8);
 
             return response()->json($user_equipments, 200);
         } catch (\Throwable $e) {


### PR DESCRIPTION
issue: #98 

背景：
index, getAllEquipmentOfUserメソッドで返却するデータがページネーションデータになっていおらず、全てをそのまま返却してしまっている

確認手順；

- [ ] MyEquipmentControllerのコードを確認するとpaginateメソッドを使っていないことが確認できる
postmanで確認

- [ ] myEquipmentGetAllApiを実行するとページネーションデータで無く全件データが取得されることが確認できる
- [ ] getAllEquipmentOfUserApiを実行するとページネーションデータで無いデータが取得されることが確認できる

やったこと：
index、getAllEquipmentOfUserApiメソッドの返却データをpaginateメソッドを使ってページネーションデータを返却するように修正

レビューお願いします

自作のPaginationコンポーネントを使用して実装