### PR TITLE
add: MyEquipmentControllerに検索機能を実装

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -54,6 +54,8 @@ Route::get('api/tennis_profiles/user/{userId}', [TennisProfileController::class,
 
 Route::apiResource('api/my_equipments', MyEquipmentController::class);
 Route::get('/api/my_equipments/user/{id}', [ MyEquipmentController::class, 'getAllEquipmentOfUser']);
+Route::get('/api/my_equipments/user/{id}/search', [ MyEquipmentController::class, 'searchEquipmentOfUser']);
+
 
 // Route::group(function() {
 //     Route::apiResource('api/my_equipments', MyEquipmentController::class);


### PR DESCRIPTION
_**issue:**_ #100

_**背景：**_
my_equipment検索機能が実装されていない

_**確認手順：**_
MyEquipmentControllerファイルを確認すると検索機能が実装されていないこの他確認できる

_**検索query項目：**_
several_words (キーワード)
search_date (日付指定)
stringing_way (張り方)
date_range_type (以前<=、以後>=)

_**検索処理項目：**_
racket_id
stringing_way
main_gut_id
cross_gut_id
new_gut_date

_**やったこと：**_

- [ ] searchEquipmentOfUserメソッドを作成

- [ ] 検索処理項目に関して大まかに、racket、gut、stringing_way、new_gut_dateを独立したand検索になるように検索を実装

_**備考：**_

-  検索項目は追加される可能性あり。

-  foreachで記述している部分が複数あるが、少し冗長な感じがするので改善できるかもしれない。

- racket,gutでのキーワード検索実装方法を初めは各テーブルをjoinさせてやればいいと考えていたが、gutの部分でmyEquipmentsテーブルはmain_gut_id, cross_gut_idの2つが同一テーブルを参照するためjoinの方法が思いつかず、最終的にキーワードに合致するgutを先に取得してきて、そのgut_idがmyEquipmentのmain_gut_idもしくはcross_gut_idと一致するものを取ってくるように実装した


レビューお願いいたします