### PR TITLE
Feature/#102/202401/ryuichi works/modify store and update method at gut review controller

### DIFF
--- a/app/Http/Controllers/GutReviewController.php
+++ b/app/Http/Controllers/GutReviewController.php
@@ -138,7 +138,28 @@ class GutReviewController extends Controller
         $validated = $request->validated();
 
         try {
+            DB::beginTransaction();
+
             $gut_review = GutReview::findOrFail($id);
+
+            // my_equipmentも変更したい時の処理
+            if($validated['need_editing_my_equipment']) {
+                $myEquipment = MyEquipment::findOrFail($gut_review->equipment_id);
+
+                $myEquipment->user_height       = $validated['user_height'];
+                $myEquipment->user_age          = $validated['user_age'];
+                $myEquipment->experience_period = $validated['experience_period'];
+                $myEquipment->racket_id         = $validated['racket_id'];
+                $myEquipment->stringing_way     = $validated['stringing_way'];
+                $myEquipment->main_gut_id       = $validated['main_gut_id'];
+                $myEquipment->main_gut_guage    = $validated['main_gut_guage'];
+                $myEquipment->main_gut_tension  = $validated['main_gut_tension'];
+                $myEquipment->cross_gut_id      = $validated['cross_gut_id'];
+                $myEquipment->cross_gut_guage   = $validated['cross_gut_guage'];
+                $myEquipment->cross_gut_tension = $validated['cross_gut_tension'];
+
+                $myEquipment->save();
+            }
 
             $gut_review->match_rate = $validated['match_rate'];
             $gut_review->pysical_durability = $validated['pysical_durability'];
@@ -146,6 +167,8 @@ class GutReviewController extends Controller
             $gut_review->review = empty($validated['review']) ? '' : $validated['review'];
 
             if ($gut_review->save()) {
+                DB::commit();
+
                 return response()->json('ガットレビューを更新しました', 200);
             }
         } catch (\ModelNotFoundException $e) {

--- a/app/Http/Requests/GutReview/GutReviewStoreRequest.php
+++ b/app/Http/Requests/GutReview/GutReviewStoreRequest.php
@@ -24,11 +24,30 @@ class GutReviewStoreRequest extends FormRequest
     public function rules()
     {
         return [
-            'equipment_id' => ['required', 'integer', 'exists:my_equipments,id'],
-            'match_rate' => ['required','numeric'],
-            'pysical_durability' => ['required','numeric'],
+            'match_rate'             => ['required','numeric'],
+            'pysical_durability'     => ['required','numeric'],
             'performance_durability' => ['required','numeric'],
-            'review' => ['nullable','string', 'max:500'],
+            'review'                 => ['nullable','string', 'max:500'],
+
+            // 登録済みのmy_equpipmentでレビューを書いた場合使用
+            'equipment_id' => ['nullable', 'integer', 'exists:my_equipments,id'],
+
+            // 未登録のmy_equpipmentでレビューを投稿しようとした場合
+            // gut_reviewと同時にmy_equipment新規登録するために使用
+            'need_creating_my_equipment' => ['nullable', 'boolean'],
+            'user_height'       => ['nullable', 'string', 'max:20'],
+            'user_age'          => ['nullable', 'string', 'max:20'],
+            'experience_period' => ['nullable', 'integer'],
+
+            'racket_id'         => ['nullable', 'integer', 'exists:rackets,id'],
+            'stringing_way'     => ['nullable', 'string', 'max:20'],
+            'main_gut_id'       => ['nullable', 'integer', 'exists:guts,id'],
+            'main_gut_guage'    => ['nullable', 'numeric',],
+            'main_gut_tension'  => ['nullable', 'integer'],
+            'cross_gut_id'      => ['nullable', 'integer', 'exists:guts,id'],
+            'cross_gut_guage'   => ['nullable', 'numeric',],
+            'cross_gut_tension' => ['nullable', 'integer'],
+            'new_gut_date'      => ['nullable', 'date'],
         ];
     }
 }

--- a/app/Http/Requests/GutReview/GutReviewUpdateRequest.php
+++ b/app/Http/Requests/GutReview/GutReviewUpdateRequest.php
@@ -28,6 +28,21 @@ class GutReviewUpdateRequest extends FormRequest
             'pysical_durability' => ['required','numeric'],
             'performance_durability' => ['required','numeric'],
             'review' => ['nullable','string', 'max:500'],
+
+            // my_equipmentも更新するときに使用
+            'need_editing_my_equipment' => ['nullable', 'boolean'],
+            'user_height'       => ['nullable', 'string', 'max:20'],
+            'user_age'          => ['nullable', 'string', 'max:20'],
+            'experience_period' => ['nullable', 'integer'],
+            'racket_id'         => ['nullable', 'integer', 'exists:rackets,id'],
+            'stringing_way'     => ['nullable', 'string', 'max:20'],
+            'main_gut_id'       => ['nullable', 'integer', 'exists:guts,id'],
+            'main_gut_guage'    => ['nullable', 'numeric',],
+            'main_gut_tension'  => ['nullable', 'integer'],
+            'cross_gut_id'      => ['nullable', 'integer', 'exists:guts,id'],
+            'cross_gut_guage'   => ['nullable', 'numeric',],
+            'cross_gut_tension' => ['nullable', 'integer'],
+            'new_gut_date'      => ['nullable', 'date'],
         ];
     }
 }


### PR DESCRIPTION
_**issue:**_ #102 

_**現状：**_
gut_reviewで登録する装備情報をmy_equipment のidを使って外部キーとして扱っているが、**フロント側でgut_review 登録処理を記述する際に、my_equipmentsテーブルにない構成の装備でgut_reviewを登録したい場合があると考えられる**。例えばまだmy_equipmentとして登録していない構成装備でレビューと一緒に作成したいときなどがあるが、現状は既存のmy_equipmentを参照する方法しか実装されていない。
また、gut_reviewのupdateの際にmy_equipment側の情報を

_**確認手順：**_
- [ ] GurReviewControllerファイルを確認する
- [ ] storeメソッド内の登録処理で既存のmy_equipmentのidのみを参照して登録処理が記述してあることが確認できる

_**やったこと：**_

- [ ] GutReviewController、storeメソッドに**need_creating_my_equipment**という識別プロパティーでこれがtrueの時にgut_review登録と同時にmy_equipmentを新規に追加する処理を実装
- [ ] GutReviewController、updateメソッドに**need_editing_my_equipment**という識別プロパティーでこれがtrueの時にgut_review更新と同時にmy_equipmentを更新する処理を実装

_**備考：**_
2種類のテーブルに変更を加える処理のため、**DBのtransaction**処理で登録更新を保証している。

レビューお願いします