### PR TITLE
modify:#107:experience_periodとtennis_profilesテーブルの項目との複合検索時のエラーの修正

### DIFF
--- a/app/Http/Controllers/GutReviewController.php
+++ b/app/Http/Controllers/GutReviewController.php
@@ -285,7 +285,7 @@ class GutReviewController extends Controller
                 }
 
                 if($experience_period || $experience_period === 0) {
-                    searchGutReviewWithEqualityComparison($gutReviewQuery,'experience_period', $experience_period);
+                    searchGutReviewWithEqualityComparison($gutReviewQuery,'my_equipments.experience_period', $experience_period);
                 }
 
                 if($racket_id) {


### PR DESCRIPTION
_**issue:**_ #107 

_**現状；**_
experience_periodとtennis_profileテーブルの項目との複合検索で下記のエラーが出て検索できなくなっている。
Integrity constraint violation: 1052 Column 'experience_period' in where clause is ambiguous 

_**確認手順：**_
postmanで確認

- [ ] gutReviewSearchApiでexperience_periodとtennis_profile項目のどれかで検索してみる
- [ ] 上記で示したエラーが発生している

<img width="1440" alt="スクリーンショット 2024-01-17 午前4 41 36" src="https://github.com/ryuichi-works/strii-backend/assets/58509835/dee10f62-68dc-48f3-935c-91ca8d8f46f6">


_**考えられる原因：**_
gut_reviewで登録しているexperience_periodは投稿ユーザーのtennis_profileのexperience_periodを元に登録してあり、またどちらも絡む名がexperience_periodで同じなため、検索処理の記述でmysqlがどちらのカラムかを判別する時の情報がなく、上記で示したエラー分ないのambiguous（曖昧な）ものとしてエラーとなっていると考えられる

_**やったこと：**_

- [ ] 曖昧な指定法となっていた部分を、テーブルを明示的に指定した記述法で下記の様に修正した
誤：experience_period
正：my_equipments.experience_period

結果：
<img width="1440" alt="スクリーンショット 2024-01-17 午前5 06 12" src="https://github.com/ryuichi-works/strii-backend/assets/58509835/e96040a4-8210-4881-ba75-f3e5d12a2ae5">


レビューお願いします