### PR TITLE
modify: experience_periodが0の時にキャスト変換でnullとなってしまっていたことへの対処

### DIFF
--- a/app/Http/Controllers/GutReviewController.php
+++ b/app/Http/Controllers/GutReviewController.php
@@ -215,7 +215,9 @@ class GutReviewController extends Controller
             // 関連テーブルのmy_equipmentsでの検索項目
             $user_height = $request->query('user_height');
             $user_age = $request->query('user_age');
-            $experience_period = (int) $request->query('experience_period');
+            $experience_period = $request->query('experience_period')
+                ?  (int) $request->query('experience_period')
+                : null;
             $racket_id = $request->query('racket_id');
             $stringing_way = $request->query('stringing_way');
             $main_gut_id = $request->query('main_gut_id');


### PR DESCRIPTION
issue: #109 

背景：
gut_review検索でexperience_periodが渡ってきていない時にexperience_periodが0として検索されてしまっている。
0の時に0で検索、nullとは分けて検索されて欲しかった。

確認手順：

- [ ] GutReviewControllerのgutReviewSearchメソッド内でexperience_periodをqueryから取得している部分にブレークポイントを置いてデバッガーを使ってみる
- [ ] experience_periodをqueryから取得している部分のphpのキャストでの方変換時にnullが0として変換されてしまっているのが確認できる

やったこと：

- [ ] 条件分岐でexperience_periodが渡ってきていない時はnullとなる用に修正

レビューお願いします