### PR TITLE
modify: userプロフィール画像登録処理で画像リサイズ処理を追加した

### DIFF
--- a/app/Http/Controllers/User/UserController.php
+++ b/app/Http/Controllers/User/UserController.php
@@ -96,10 +96,6 @@ class UserController extends Controller
 
                     $user->file_path = $trimedFilePath;
                 }
-
-
-
-                $user->file_path = $trimedFilePath;
             }
 
             $user->name = $validated['name'];

--- a/app/Http/Controllers/User/UserController.php
+++ b/app/Http/Controllers/User/UserController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Storage;
 use App\Models\User;
+use Intervention\Image\Facades\Image;
 
 class UserController extends Controller
 {
@@ -55,33 +56,61 @@ class UserController extends Controller
             'email' => ['required', 'email'],
             'file' => ['nullable', 'file']
         ]);
-        
+
         try {
             $user = User::findOrFail($id);
 
             //新しいファイルがあれば新たにstorageに登録
-            if($file = $request->file('file')) {
-                $filename = uniqid(rand(0, 99) . "_user_") . "." . $request->file('file')->extension();
-        
-                $path = $file->storeAs('images/users', $filename, 'public');
+            if ($file = $request->file('file')) {
 
-                //以前のイメージファイルがあればstorageフォルダから削除
-                if($user->file_path) {
-                    Storage::disk('public')->delete($user->file_path);
+                // 画像ファイルリサイジング
+                $file = Image::make($request->file('file'));
+                $file->orientate();
+                $file->resize(
+                    300,
+                    null,
+                    function ($constraint) {
+                        // 縦横比を保持したままにする
+                        $constraint->aspectRatio();
+                        // 小さい画像は大きくしない
+                        $constraint->upsize();
+                    }
+                );
+
+                $filename = uniqid(rand(0, 99) . "_user_") . "." . $user->id . "." . $request->file('file')->extension();
+
+                // storageに登録するためのpathを生成
+                $storagePath = storage_path('app/public/images/users');
+                $fileLocationFullPath = $storagePath . '/' . $filename;
+
+                if ($file->save($fileLocationFullPath)) {
+                    // "/var/www/html/strii-backend/storage/app/public/images/users/~~~.jpg"
+                    // intervension image導入前の登録の仕様に合わせるため
+                    // 上記のようなfullPathをDBのfile_pathカラム用に整形
+                    $trimedFilePath = strstr($fileLocationFullPath, 'images');
+
+                    //以前のイメージファイルがあればstorageフォルダから削除
+                    if ($user->file_path) {
+                        Storage::disk('public')->delete($user->file_path);
+                    }
+
+                    $user->file_path = $trimedFilePath;
                 }
 
-                $user->file_path = $path;
+
+
+                $user->file_path = $trimedFilePath;
             }
 
             $user->name = $validated['name'];
             $user->email = $validated['email'];
 
-            if($user->save()) {
+            if ($user->save()) {
                 return response()->json('ユーザー情報を更新しました', 200);
             }
-        }catch(\ModelNotFoundException $e) {
+        } catch (\ModelNotFoundException $e) {
             throw $e;
-        }catch(\Throwable $e) {
+        } catch (\Throwable $e) {
             \Log::error($e);
 
             throw $e;


### PR DESCRIPTION
### issue
#114 

### 背景：
userプロフィール画像登録処理でフロントから渡ってきた画像をそのままstorageに保存してしまっており、容量が多くなってしまう状態である

### 確認手順：

- [ ] UserController.phpを確認しに行く
- [ ] 画像登録処理においてフロントから渡ってきた画像ファイルをそのまま保存してしまっているのが確認できる

### やったこと

- [ ] UserControllerのupdateメソッド内の画像更新処理でintervention imageを使った画像トリミング処理を追加した

### 備考：
GutImageControllerのupdateメソッドを参考にして実装している

レビューお願いします