### PR TITLE
modify:racketsテーブルの修正とその関連するものの修正・追加

### DIFF
--- a/app/Http/Controllers/RacketSeriesController.php
+++ b/app/Http/Controllers/RacketSeriesController.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\RacketSeries;
+
+use App\Http\Requests\RacketSeriesRequests\RacketSeriesStoreRequest;
+use App\Http\Requests\RacketSeriesRequests\RacketSeriesUpdateRequest;
+
+class RacketSeriesController extends Controller
+{
+    public function __construct()
+    {
+        $this->middleware('auth:admin')->only(['store', 'update', 'destroy']);
+    }
+    
+    /**
+     * Display a listing of the resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function index()
+    {
+        try {
+            // $racketSeries = RacketSeries::all();
+            $racketSeries = RacketSeries::with('maker')->get();
+
+            return response()->json($racketSeries, 200);
+        } catch (\Throwable $e) {
+            \Log::error($e);
+
+            throw $e;
+        }
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function store(RacketSeriesStoreRequest $request)
+    {
+        $validated_request = $request->validated();
+
+        try {
+            $racketSeries = RacketSeries::create($validated_request);
+
+            return response()->json($racketSeries, 200);
+        } catch (\Throwable $e) {
+            \Log::error($e);
+
+            throw $e;
+        }
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function show($id)
+    {
+        try {
+            $racketSeries = RacketSeries::findOrFail($id);
+
+            return response()->json($racketSeries, 200);
+        } catch (ModelNotFoundException $e) {
+            // データが見つからなかっただけならロギング不要
+            throw $e;
+        } catch (\Throwable $e) {
+            \Log::error($e);
+
+            throw $e;
+        }
+    }
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function update(RacketSeriesUpdateRequest $request, $id)
+    {
+        $validated_request = $request->validated();
+
+        try {
+            $racketSeries = RacketSeries::findOrFail($id);
+
+            $racketSeries->name_ja = $validated_request['name_ja'];
+            
+            if ($racketSeries->name_en) $racketSeries->name_en = $validated_request['name_en'];
+
+            $racketSeries->maker_id = $validated_request['maker_id'];
+
+            if($racketSeries->save()) {
+                return response()->json([
+                    'messages' => 'completed updating racketSeries',
+                    'status' => 'ok'
+                ], 200);
+            }
+        } catch (ModelNotFoundException $e) {
+            // データが見つからなかっただけならロギング不要
+            throw $e;
+        } catch (\Throwable $e) {
+            \Log::error($e);
+            
+            throw $e;
+        }
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy($id)
+    {
+        try {
+            $racketSeries = RacketSeries::findOrFail($id);
+            $racketSeries->delete();
+
+            return response()->json([
+                'massages' => 'deleted',
+                'status' => 'ok'
+            ], 200);
+        } catch (\Throwable $e) {
+            \Log::error($e);
+
+            throw $e;
+        }
+    }
+}

--- a/app/Http/Requests/RacketSeriesRequests/RacketSeriesStoreRequest.php
+++ b/app/Http/Requests/RacketSeriesRequests/RacketSeriesStoreRequest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Requests\RacketSeriesRequests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class RacketSeriesStoreRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules()
+    {
+        return [
+            'name_ja' => ['required', 'string', 'max:30'],
+            'name_en' => ['string', 'max:30'],
+            'maker_id' => ['required', 'integer', 'exists:makers,id'],
+        ];
+    }
+}

--- a/app/Http/Requests/RacketSeriesRequests/RacketSeriesUpdateRequest.php
+++ b/app/Http/Requests/RacketSeriesRequests/RacketSeriesUpdateRequest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Requests\RacketSeriesRequests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class RacketSeriesUpdateRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules()
+    {
+        return [
+            'name_ja' => ['required', 'string', 'max:30'],
+            'name_en' => ['string', 'max:30'],
+            'maker_id' => ['required', 'integer', 'exists:makers,id'],
+        ];
+    }
+}

--- a/app/Models/Maker.php
+++ b/app/Models/Maker.php
@@ -32,4 +32,9 @@ class Maker extends Model
     {
         return $this->hasMany(RacketImage::class);
     }
+
+    public function racketSeries()
+    {
+        return $this->hasMany(RacketSeries::class);
+    }
 }

--- a/app/Models/Racket.php
+++ b/app/Models/Racket.php
@@ -36,4 +36,14 @@ class Racket extends Model
     {
         return $this->hasMany(MyEquipment::class);
     }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class, 'posting_user_id', 'id');
+    }
+
+    public function series()
+    {
+        return $this->belongsTo(RacketSeries::class, 'series_id', 'id');
+    }
 }

--- a/app/Models/RacketImage.php
+++ b/app/Models/RacketImage.php
@@ -24,4 +24,9 @@ class RacketImage extends Model
     {
         return $this->belongsTo(Maker::class);
     }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class, 'posting_user_id', 'id');
+    }
 }

--- a/app/Models/RacketSeries.php
+++ b/app/Models/RacketSeries.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class RacketSeries extends Model
+{
+    use HasFactory;
+
+    public function rackets()
+    {
+        return $this->hasMany(Racket::class, 'series_id', 'id');
+    }
+}

--- a/app/Models/RacketSeries.php
+++ b/app/Models/RacketSeries.php
@@ -9,8 +9,19 @@ class RacketSeries extends Model
 {
     use HasFactory;
 
+    protected $fillable = [
+        'name_ja',
+        'name_en',
+        'maker_id',
+    ];
+
     public function rackets()
     {
         return $this->hasMany(Racket::class, 'series_id', 'id');
+    }
+
+    public function maker()
+    {
+        return $this->belongsTo(Maker::class);
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -57,4 +57,14 @@ class User extends Authenticatable
     {
         return $this->hasMany(GutReview::class);
     }
+
+    public function rackets()
+    {
+        return $this->hasMany(Racket::class, 'posting_user_id', 'id');
+    }
+
+    public function racket_images()
+    {
+        return $this->hasMany(RacketImage::class, 'posting_user_id', 'id');
+    }
 }

--- a/database/migrations/2024_02_08_082403_create_racket_series_table.php
+++ b/database/migrations/2024_02_08_082403_create_racket_series_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('racket_series', function (Blueprint $table) {
+            $table->id();
+            $table->string('name_ja', 30)->nullable(false);
+            $table->string('name_en', 30)->nullable()->default("");
+            $table->foreignId('maker_id')->constrained('makers');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('racket_series');
+    }
+};

--- a/database/migrations/2024_02_08_103056_add_columns_to_rackets_table.php
+++ b/database/migrations/2024_02_08_103056_add_columns_to_rackets_table.php
@@ -1,0 +1,45 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('rackets', function (Blueprint $table) {
+            $table->foreignId('posting_user_id')->nullable()->constrained('users');
+            $table->foreignId('series_id')->nullable()->constrained('racket_series');
+            $table->integer('head_size')->nullable()->unsigned();
+            $table->string('pattern')->default('');
+            $table->integer('weight')->nullable()->unsigned();
+            $table->integer('balance')->nullable()->unsigned();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('rackets', function (Blueprint $table) {
+            $table->dropForeign('rackets_posting_user_id_foreign');
+            $table->dropColumn('posting_user_id');
+
+            $table->dropForeign('rackets_series_id_foreign');
+            $table->dropColumn('series_id');
+
+            $table->dropColumn('head_size');
+            $table->dropColumn('weight');
+            $table->dropColumn('balance');
+        });
+    }
+};

--- a/database/migrations/2024_02_09_103600_add_column_posting_user_id_to_racket_images_table.php
+++ b/database/migrations/2024_02_09_103600_add_column_posting_user_id_to_racket_images_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('racket_images', function (Blueprint $table) {
+            $table->foreignId('posting_user_id')->constrained('users');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('racket_images', function (Blueprint $table) {
+            $table->dropForeign('racket_images_posting_user_id_foreign');
+            $table->dropColumn('posting_user_id');
+        });
+    }
+};

--- a/database/migrations/2024_02_09_145456_change_column_image_id_nullable_to_not_null_at_rackets_table.php
+++ b/database/migrations/2024_02_09_145456_change_column_image_id_nullable_to_not_null_at_rackets_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('rackets', function (Blueprint $table) {
+            $table->foreignId('image_id')->nullable(false)->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('rackets', function (Blueprint $table) {
+            $table->foreignId('image_id')->nullable()->change();
+        });
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -20,15 +20,16 @@ class DatabaseSeeder extends Seeder
     {
         $this->call([
             MakerSeeder::class,
+            UserSeeder::class,
             RacketImageSeeder::class,
             GutImageSeeder::class,
             GutSeeder::class,
+            RacketSeriesSeeder::class,
             RacketSeeder::class,
-            UserSeeder::class,
             AdminSeeder::class,
             TennisProfileSeeder::class,
             MyEquipmentSeeder::class,
-            GutReviewSeeder::class
+            GutReviewSeeder::class,
         ]);
 
         // \App\Models\User::factory(10)->create();

--- a/database/seeders/GutImageSeeder.php
+++ b/database/seeders/GutImageSeeder.php
@@ -19,7 +19,7 @@ class GutImageSeeder extends Seeder
     {
         DB::table('gut_images')->insert([
             [
-                'file_path' => 'images/guts/sample_image1.png',
+                'file_path' => 'images/guts/default_gut.jpg',
                 'title' => 'ポリツアープロ',
                 'maker_id' => 1,
                 'created_at' => Carbon::now(),

--- a/database/seeders/GutReviewSeeder.php
+++ b/database/seeders/GutReviewSeeder.php
@@ -18,6 +18,7 @@ class GutReviewSeeder extends Seeder
     {
         DB::table('gut_reviews')->insert([
             [
+                'user_id' => 1,
                 'equipment_id' => 1,
                 'match_rate' => 4.5,
                 'pysical_durability' => 2.5,
@@ -27,6 +28,7 @@ class GutReviewSeeder extends Seeder
                 'updated_at' => Carbon::now()
             ],
             [
+                'user_id' => 2,
                 'equipment_id' => 2,
                 'match_rate' => 4.5,
                 'pysical_durability' => 2.5,
@@ -36,6 +38,7 @@ class GutReviewSeeder extends Seeder
                 'updated_at' => Carbon::now()
             ],
             [
+                'user_id' => 3,
                 'equipment_id' => 3,
                 'match_rate' => 4.5,
                 'pysical_durability' => 2.5,

--- a/database/seeders/GutSeeder.php
+++ b/database/seeders/GutSeeder.php
@@ -39,7 +39,7 @@ class GutSeeder extends Seeder
                 'name_ja' => 'プロハリケーンツアー',
                 'name_en' => '',
                 'maker_id' => 2,
-                'image_id' => null,
+                'image_id' => 1,
                 'need_posting_image' => true,
                 'created_at' => Carbon::now(),
                 'updated_at' => Carbon::now()

--- a/database/seeders/RacketImageSeeder.php
+++ b/database/seeders/RacketImageSeeder.php
@@ -18,6 +18,7 @@ class RacketImageSeeder extends Seeder
     {
         DB::table('racket_images')->insert([
             [
+                'posting_user_id' => 1,
                 'file_path' => 'images/rackets/default_racket_image.png',
                 'title' => 'デフォルトラケットイメージ',
                 'maker_id' => 1,
@@ -25,6 +26,7 @@ class RacketImageSeeder extends Seeder
                 'updated_at' => Carbon::now()
             ],
             [
+                'posting_user_id' => 2,
                 'file_path' => 'images/rackets/default_racket_image1.jpg',
                 'title' => 'ピュアアエロ',
                 'maker_id' => 3,
@@ -32,6 +34,7 @@ class RacketImageSeeder extends Seeder
                 'updated_at' => Carbon::now()
             ],
             [
+                'posting_user_id' => 3,
                 'file_path' => 'images/rackets/default_racket_image2.jpg',
                 'title' => 'ブレード',
                 'maker_id' => 4,
@@ -39,6 +42,7 @@ class RacketImageSeeder extends Seeder
                 'updated_at' => Carbon::now()
             ],
             [
+                'posting_user_id' => 3,
                 'file_path' => 'images/rackets/default_racket_image3.jpg',
                 'title' => 'プロスタッフ',
                 'maker_id' => 4,
@@ -46,6 +50,7 @@ class RacketImageSeeder extends Seeder
                 'updated_at' => Carbon::now()
             ],
             [
+                'posting_user_id' => 1,
                 'file_path' => 'images/rackets/default_racket_image4.jpg',
                 'title' => 'v コア100',
                 'maker_id' => 2,
@@ -53,6 +58,7 @@ class RacketImageSeeder extends Seeder
                 'updated_at' => Carbon::now()
             ],
             [
+                'posting_user_id' => 1,
                 'file_path' => 'images/rackets/default_racket_image5.jpg',
                 'title' => 'スピード',
                 'maker_id' => 5,
@@ -60,6 +66,7 @@ class RacketImageSeeder extends Seeder
                 'updated_at' => Carbon::now()
             ],
             [
+                'posting_user_id' => 2,
                 'file_path' => 'images/rackets/default_racket_image6.jpg',
                 'title' => 'o3',
                 'maker_id' => 6,
@@ -67,6 +74,7 @@ class RacketImageSeeder extends Seeder
                 'updated_at' => Carbon::now()
             ],
             [
+                'posting_user_id' => 3,
                 'file_path' => 'images/rackets/default_racket_image7.jpg',
                 'title' => 'ピュアドライブ',
                 'maker_id' => 3,

--- a/database/seeders/RacketSeeder.php
+++ b/database/seeders/RacketSeeder.php
@@ -18,29 +18,44 @@ class RacketSeeder extends Seeder
     {
         DB::table('rackets')->insert([
             [
+                'posting_user_id' => 1,
                 'name_ja' => 'ピュアアエロ',
                 'name_en' => 'pure aero',
                 'maker_id' => 2,
-                'image_id' => 2,
+                'image_id' => 1,
                 'need_posting_image' => true,
+                'series_id' => 2,
+                'head_size' => 100,
+                'weight' => null,
+                'balance' => null,
                 'created_at' => Carbon::now(),
                 'updated_at' => Carbon::now()
             ],
-            [
+            [   
+                'posting_user_id' => 1,
                 'name_ja' => 'Vコア 100',
                 'name_en' => 'Vcore 100',
                 'maker_id' => 1,
-                'image_id' => null,
+                'image_id' => 1,
                 'need_posting_image' => true,
+                'series_id' => 3,
+                'head_size' => 100,
+                'weight' => null,
+                'balance' => null,
                 'created_at' => Carbon::now(),
                 'updated_at' => Carbon::now()
             ],
-            [
+            [   
+                'posting_user_id' => 2,
                 'name_ja' => 'プロスタッフ95',
                 'name_en' => 'prostaf95',
                 'maker_id' => 3,
                 'image_id' => 1,
                 'need_posting_image' => true,
+                'series_id' => 1,
+                'head_size' => 95,
+                'weight' => null,
+                'balance' => null,
                 'created_at' => Carbon::now(),
                 'updated_at' => Carbon::now()
             ],

--- a/database/seeders/RacketSeriesSeeder.php
+++ b/database/seeders/RacketSeriesSeeder.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+use Carbon\Carbon;
+
+class RacketSeriesSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        DB::table('racket_series')->insert([
+            [
+                'name_ja' => 'プロスタッフ',
+                'name_en' => '',
+                'maker_id' => 4,
+                'created_at' => Carbon::now(),
+                'updated_at' => Carbon::now(),
+            ],
+            [
+                'name_ja' => 'ピュアアエロ',
+                'name_en' => '',
+                'maker_id' => 3,
+                'created_at' => Carbon::now(),
+                'updated_at' => Carbon::now(),
+            ],
+            [
+                'name_ja' => 'Vコア',
+                'name_en' => '',
+                'maker_id' => 2,
+                'created_at' => Carbon::now(),
+                'updated_at' => Carbon::now(),
+            ],
+        ]);
+    }
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -7,9 +7,9 @@ use App\Http\Controllers\MakerController;
 use App\Http\Controllers\MyEquipmentController;
 use App\Http\Controllers\RacketController;
 use App\Http\Controllers\RacketImageController;
+use App\Http\Controllers\RacketSeriesController;
 use App\Http\Controllers\TennisProfileController;
 use App\Http\Controllers\User\UserController;
-use App\Models\GutImage;
 use Illuminate\Support\Facades\Route;
 
 /*
@@ -34,6 +34,8 @@ Route::get('/', function () {
 
 
 Route::apiResource('api/makers', MakerController::class);
+
+Route::apiResource('api/racket_series', RacketSeriesController::class);
 
 Route::get('api/gut_images/search', [GutImageController::class, 'gutImageSearch']);
 Route::apiResource('api/gut_images', GutImageController::class);


### PR DESCRIPTION
**issue**
#119 

**背景：**
・racketのデータの取り扱いに関して、ここまでの設計で進めるとラケットの情報を管理者が各メーカーごとにすべてを調査する必要があり管理コストが高くなる。
・また、各メーカーでラケットの名前に関して新モデルでも名前が旧モデルとほぼ同じの場合があり、本アプリは用具の画像をユーザーから提供を受ける形にしており、画像がまだ未登録のラケットデータが名前が似通ったものだと、扱いを混同してしまうので、それを解消するためラケットの登録はユーザー側で行なってもらうとともに、使用ラケットの画像の提供を促したい。

**詳しい経緯：**
・各メーカーのラケット・ガットの情報を集めている際にガットに関しては問題ないが、ラケットに関して、ラケットは昔のモデルはだんだん使われなくなっていきデータとしての価値が下がってくる。
・また、まだ画像が登録されていないラケットの情報を使ったレビューなどを書く際に名前が似通って混同してしまうことにより、別の誤った過去モデルのラケットを選択してしまう恐れがある。
・数多くあるラケットを上記に気をつけて管理することが、現状の設計だと難しい。

**解決策：**
管理者側ではラケット自体を調査・管理するのではなく、各メーカごとにラケットがシリーズとして区分されて発売されるのでそのシリーズを調査管理することとする。そうすることでシリーズが継続している限り、そのシリーズの最新モデルの登録がユーザー側で画像付きで行われる様になり、管理コストが少なくなることが見込まれる。

**やったこと**

- [ ] racketsテーブルにposting_user_id、series_id、head_size、pattern、weightカラムを追加
- [ ] recket_seriesテーブルを作成
- [ ] racketsテーブルとracket_seriesテーブル、makerテーブルのリレーションを設定
- [ ] 変更によるseederのダミーデータの修正
- [ ] racketsテーブルのimage_idカラムのnullable制約をNOT NULLに変更。これはracketをユーザーに登録してもらう設計に変更したため必須としている

**備考：**
今回の変更による影響箇所としてracketsテーブルのimage_idカラムに修正を修正しているが、現状考えられる影響としてフロントからのリクエストの返却するデータとしてracketなどを返却している箇所が影響範囲に考えられる。しかし、実際どうかはフロントエンドと連携して検証したいため、返却データに関してはまだ修正を入れていないので、今後フロントエンドのコードを修正するときに一緒に考慮して修正していく。

レビューお願いします