### PR TITLE
modify: GutReviewコントローラーupdateメソッド内で追加で行っているmyEquipmentの更新カラムを調整

### DIFF
--- a/app/Http/Controllers/GutReviewController.php
+++ b/app/Http/Controllers/GutReviewController.php
@@ -145,10 +145,7 @@ class GutReviewController extends Controller
             // my_equipmentも変更したい時の処理
             if($validated['need_editing_my_equipment']) {
                 $myEquipment = MyEquipment::findOrFail($gut_review->equipment_id);
-
-                $myEquipment->user_height       = $validated['user_height'];
-                $myEquipment->user_age          = $validated['user_age'];
-                $myEquipment->experience_period = $validated['experience_period'];
+                
                 $myEquipment->racket_id         = $validated['racket_id'];
                 $myEquipment->stringing_way     = $validated['stringing_way'];
                 $myEquipment->main_gut_id       = $validated['main_gut_id'];


### PR DESCRIPTION
### issue
#123 

### 背景：
review更新画面でのmy_equipment情報の更新でmy_equipmentのuser_age, experience_period, user_heightカラムの値は更新されない様にしてあるが、更新処理の時に更新する記述をしていたためフロントから値が渡ってきておらずにエラーとなっていことの修正

### 確認手順

- [ ] review一覧画面から更新画面に遷移する
- [ ] my_equipment情報の変更を含むreview更新処理を行う
- [ ] user_age, experience_period, user_heightカラムに関するエラーとなることが確認できる

### やったこと

- [ ] GutReviewコントローラーupdateメソッドでmyEquipmentテーブルも更新しているがそこの更新カラムのuser_height、user_age、experience_periodカラムはGutReviewからは更新されない様に削除した

### 備考
GutReviewコントローラーでGutReviewだけでなく、myEquipmentの情報も更新させているのは、フロントで更新操作をする際にgutReviewとmyEquipmentの2つの更新画面に移動して更新させる手間を省くために、ユーザービリティーを考えて単一操作で更新される様にしたかったためである。
