### PR TITLE
modify: RacketSeriesController,showメソッドでmaker情報をwithメソッドで取得するよう修正

### DIFF
--- a/app/Http/Controllers/RacketSeriesController.php
+++ b/app/Http/Controllers/RacketSeriesController.php
@@ -64,7 +64,7 @@ class RacketSeriesController extends Controller
     public function show($id)
     {
         try {
-            $racketSeries = RacketSeries::findOrFail($id);
+            $racketSeries = RacketSeries::with('maker')->findOrFail($id);
 
             return response()->json($racketSeries, 200);
         } catch (ModelNotFoundException $e) {


### PR DESCRIPTION
### issue
#126 

### 背景
RacketSeriesテーブルはmakersテーブルとリレーション関係があり、データを返却する際にmakerをwithメソッドでeager loadingさせてmakerの情報も含んだものを返却する必要があり、showメソッドでその記述を忘れていた

### 確認手順

- [ ] RacketSeriesControllerを確認する

- [ ] showメソッドの返却データにmaker情報がwithメソッドで取得されていないことが確認できる。

### やったこと

- [ ] showメソッドでRacketSeriesのデータを取得する際にwithメソッドでmaker情報をeager loadingするように修正

レビューお願いします。