### PR TITLE
modify: racketsテーブルに新規追加したカラムによるRacketControllerの影響箇所の修正

### DIFF
--- a/app/Http/Controllers/RacketController.php
+++ b/app/Http/Controllers/RacketController.php
@@ -55,6 +55,12 @@ class RacketController extends Controller
                 'maker_id' => $validated['maker_id'],
                 'image_id' => isset($validated['image_id']) ? $validated['image_id'] : null,
                 'need_posting_image' => $validated['need_posting_image'],
+                'posting_user_id' => $validated['posting_user_id'],
+                'series_id' => isset($validated['series_id']) ? $validated['series_id'] : null,
+                'head_size' => isset($validated['head_size']) ? $validated['head_size'] : null,
+                'pattern' => $validated['pattern'],
+                'weight' => isset($validated['weight']) ? $validated['weight'] : null,
+                'balance' => isset($validated['balance']) ? $validated['balance'] : null,
             ]);
 
             if ($racket) {

--- a/app/Http/Controllers/RacketController.php
+++ b/app/Http/Controllers/RacketController.php
@@ -23,7 +23,12 @@ class RacketController extends Controller
     public function index()
     {
         try {
-            $rackets = Racket::with(['maker', 'racketImage'])->paginate(8);
+            $rackets = Racket::with([
+                'maker',
+                'racketImage',
+                'user',
+                'series'
+            ])->paginate(8);
 
             return response()->json($rackets, 200);
         } catch (\Throwable $e) {
@@ -71,7 +76,12 @@ class RacketController extends Controller
     public function show($id)
     {
         try {
-            $racket = Racket::with(['maker', 'racketImage'])->findOrFail($id);
+            $racket = Racket::with([
+                'maker',
+                'racketImage',
+                'user',
+                'series',
+            ])->findOrFail($id);
 
             return response()->json($racket, 200);
         } catch (\ModelNotFoundException $e) {

--- a/app/Http/Controllers/RacketController.php
+++ b/app/Http/Controllers/RacketController.php
@@ -113,11 +113,17 @@ class RacketController extends Controller
         try {
             $racket = Racket::findOrFail($id);
 
-            $racket->name_ja = $validated['name_ja'];
-            $racket->name_en = $validated['name_en'];
-            $racket->maker_id = $validated['maker_id'];
-            $racket->image_id = isset($validated['image_id']) ? $validated['image_id'] : null;
-            $racket->need_posting_image = $validated['need_posting_image'];
+            $racket->name_ja  = isset($validated['name_ja']) ? $validated['name_ja'] : $racket->name_ja;
+            $racket->name_en  = isset($validated['name_en']) ? $validated['name_en'] : $racket->name_en;
+            $racket->maker_id = isset($validated['maker_id']) ? $validated['maker_id'] : $racket->maker_id;
+            $racket->image_id = isset($validated['image_id']) ? $validated['image_id'] : $racket->image_id;
+            $racket->need_posting_image = isset($validated['need_posting_image']) ? $validated['need_posting_image'] : $racket->need_posting_image;
+            $racket->posting_user_id = isset($validated['posting_user_id']) ? $validated['posting_user_id'] : $racket->posting_user_id;
+            $racket->series_id = isset($validated['series_id']) ? $validated['series_id'] : $racket->series_id;
+            $racket->head_size = isset($validated['head_size']) ? $validated['head_size'] : $racket->head_size;
+            $racket->pattern   = isset($validated['pattern']) ? $validated['pattern'] : $racket->pattern;
+            $racket->weight    = isset($validated['weight']) ? $validated['weight'] : $racket->weight;
+            $racket->balance   = isset($validated['balance']) ? $validated['balance'] : $racket->balance;
 
             if ($racket->save()) {
                 return response()->json('ラケット情報を更新しました', 200);

--- a/app/Http/Controllers/RacketController.php
+++ b/app/Http/Controllers/RacketController.php
@@ -12,7 +12,7 @@ class RacketController extends Controller
 {
     public function __construct()
     {
-        $this->middleware('auth:admin')->only(['store', 'update', 'destroy']);
+        $this->middleware('auth:admin')->only(['update', 'destroy']);
     }
 
     /**

--- a/app/Http/Controllers/RacketController.php
+++ b/app/Http/Controllers/RacketController.php
@@ -194,8 +194,6 @@ class RacketController extends Controller
         return response()->json($responseRackets, 200);
     }
 
-
-
     public function racketSearch(Request $request)
     {
         $severalWords = $request->query('several_words');
@@ -209,39 +207,79 @@ class RacketController extends Controller
         }
 
         $maker_id = $request->query('maker');
+        $series_id = $request->query('series_id');
+        $head_size = $request->query('head_size');
+        $pattern = $request->query('pattern');
+        $weight = $request->query('weight');
+        $balance = $request->query('balance');
 
         $racketQuery = Racket::query();
 
-        if ($severalWords && $maker_id) {
-            foreach ($severalWordsArray as $word) {
-                //severalWordsで複数取れてきてもmakerが一致しない場合は弾かれる
-                $racketQuery
-                    ->orWhere(function ($racketQuery) use ($word, $maker_id) {
-                        $racketQuery
-                            ->where(function ($racketQuery) use ($word, $maker_id) {
-                                $racketQuery
-                                    ->orWhere('name_ja', 'like', '%' . $word . '%')
-                                    ->orWhere('name_en', 'like', '%' . $word . '%');
-                            })
-                            ->where('maker_id', '=', $maker_id);
-                    });
-            }
-        } elseif ($severalWords && empty($maker_id)) {
-            //makerの指定がないのでseveralWordsのor検索となる
-            foreach ($severalWordsArray as $word) {
-                $racketQuery
-                    ->orWhere('name_ja', 'like', '%' . $word . '%')
-                    ->orWhere('name_en', 'like', '%' . $word . '%');
-            }
-        } elseif (empty($severalWords) && $maker_id) {
-            //makerのみでの検索
-            $racketQuery->where('maker_id', '=', $maker_id);
+        // メーカーで検索
+        if ($maker_id) {
+            $racketQuery->where(function ($racketQuery) use ($maker_id) {
+                $racketQuery->where('maker_id', '=', $maker_id);
+            });
+        }
+
+        // ラケットシリーズで検索
+        if ($series_id) {
+            $racketQuery->where(function ($racketQuery) use ($series_id) {
+                $racketQuery->where('series_id', '=', $series_id);
+            });
+        }
+
+        // ヘッドサイズで検索
+        if ($head_size) {
+            $racketQuery->where(function ($racketQuery) use ($head_size) {
+                $racketQuery->where('head_size', '=', $head_size);
+            });
+        }
+
+        // ストリングパターンで検索
+        if ($pattern) {
+            $racketQuery->where(function ($racketQuery) use ($pattern) {
+                $racketQuery->where('pattern', '=', $pattern);
+            });
+        }
+
+        // 重さで検索
+        if ($weight) {
+            $racketQuery->where(function ($racketQuery) use ($weight) {
+                $racketQuery->where('weight', '=', $weight);
+            });
+        }
+
+        // バランスポイントで検索
+        if ($balance) {
+            $racketQuery->where(function ($racketQuery) use ($balance) {
+                $racketQuery->where('balance', '=', $balance);
+            });
+        }
+
+        // キーワード検索
+        if ($severalWords) {
+            $racketQuery->where(function ($racketQuery) use ($severalWordsArray) {
+                foreach ($severalWordsArray as $word) {
+                    $racketQuery
+                        ->orWhere('name_ja', 'like', '%' . $word . '%')
+                        ->orWhere('name_en', 'like', '%' . $word . '%');
+                }
+            });
         }
 
         $searchedRackets = $racketQuery
             ->with(['maker', 'racketImage'])
             ->paginate(8)
-            ->appends(['several_words' => $severalWords, 'maker' => $maker_id]);
+            ->appends([
+                'several_words' => $severalWords,
+                'maker' => $maker_id,
+                'series_id' => $series_id,
+                'head_size' => $head_size,
+                'pattern' => $pattern,
+                'weight' => $weight,
+                'balance' => $balance,
+            ]);
 
         return response()->json($searchedRackets, 200);
     }

--- a/app/Http/Requests/Racket/RacketStoreRequest.php
+++ b/app/Http/Requests/Racket/RacketStoreRequest.php
@@ -4,6 +4,8 @@ namespace App\Http\Requests\Racket;
 
 use Illuminate\Foundation\Http\FormRequest;
 
+use App\Rules\AgreementConfirmation;
+
 class RacketStoreRequest extends FormRequest
 {
     /**
@@ -28,7 +30,14 @@ class RacketStoreRequest extends FormRequest
             'name_en' => ['max:30'],
             'maker_id' => ['required', 'integer', 'exists:makers,id'],
             'image_id' => ['sometimes', 'integer', 'exists:racket_images,id'],
-            'need_posting_image' => ['required','boolean']
+            'need_posting_image' => ['required', 'boolean'],
+            'posting_user_id' => ['required', 'integer', 'exists:users,id'],
+            'series_id' => ['nullable', 'integer', 'exists:racket_series,id'],
+            'head_size' => ['required', 'integer', 'max:150'],
+            'pattern' => ['required', 'string', 'max:15'],
+            'weight' => ['nullable', 'integer', 'max:400'],
+            'balance' => ['nullable', 'integer', 'max:400'],
+            'agreement' => ['required', 'boolean', new AgreementConfirmation],
         ];
     }
 }

--- a/app/Http/Requests/Racket/RacketUpdateRequest.php
+++ b/app/Http/Requests/Racket/RacketUpdateRequest.php
@@ -24,11 +24,17 @@ class RacketUpdateRequest extends FormRequest
     public function rules()
     {
         return [
-            'name_ja' => ['required', 'max:30'],
-            'name_en' => ['max:30'],
-            'maker_id' => ['required', 'integer', 'exists:makers,id'],
-            'image_id' => ['sometimes', 'integer', 'exists:racket_images,id'],
-            'need_posting_image' => ['required','boolean']
+            'name_ja' => ['nullable', 'string', 'max:30'],
+            'name_en' => ['nullable', 'string','max:30'],
+            'maker_id' => ['nullable', 'integer', 'exists:makers,id'],
+            'image_id' => ['nullable', 'integer', 'exists:racket_images,id'],
+            'need_posting_image' => ['nullable','boolean'],
+            'posting_user_id' => ['nullable', 'integer', 'exists:users,id'],
+            'series_id' => ['nullable', 'integer', 'exists:racket_series,id'],
+            'head_size' => ['nullable', 'integer', 'max:150'],
+            'pattern' => ['nullable', 'string', 'max:15'],
+            'weight' => ['nullable', 'integer', 'max:400'],
+            'balance' => ['nullable', 'integer', 'max:400'],
         ];
     }
 }

--- a/app/Models/Racket.php
+++ b/app/Models/Racket.php
@@ -14,7 +14,14 @@ class Racket extends Model
         'name_en',
         'maker_id',
         'image_id',
-        'need_posting_image'
+        'need_posting_image',
+        'posting_user_id',
+        'series_id',
+        'head_size',
+        'pattern',
+        'weight',
+        'balance',
+        'agreement',
     ];
 
     public function maker()

--- a/app/Rules/AgreementConfirmation.php
+++ b/app/Rules/AgreementConfirmation.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Rules;
+
+use Illuminate\Contracts\Validation\Rule;
+
+class AgreementConfirmation implements Rule
+{
+    /**
+     * Create a new rule instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Determine if the validation rule passes.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function passes($attribute, $value)
+    {
+        // mysqlでbooleanが0,1で比較されるため===ではなく==で比較している
+        return $value == true;
+    }
+
+    /**
+     * Get the validation error message.
+     *
+     * @return string
+     */
+    public function message()
+    {
+        return 'The :attribute must be true';
+    }
+}


### PR DESCRIPTION
### issue
#125

### 背景
以前、racketsテーブルに新たにカラムを追加しており、その時の影響範囲の修正漏れがRacketControllerにあるので修正する

### 確認手順

- [ ] racketsテーブルにカラムをつかする際に作成したmigrationファイルを確認する
- [ ] posting_user_id、series_id、head_size、pattern、weight、balanceカラムを追加しているのが確認できる。
- [ ] 次にRacketControllerファイルを確認する。
- [ ] storeメソッドなどで追加したカラムを反映していないコードがあることが確認できる。

### やったこと

- [ ] index、showメソッドで追加カラムによる影響の修正
- [ ] storeメソッドで追加カラムによる影響の修正
- [ ] racket登録をユーザーでもできるようにコントローラmiddlewareを修正
- [ ] updateメソッドで追加カラムによる影響の修正
- [ ] racketSearchメソッドを追加したカラムでも検索できるように修正

### 備考

- 検索メソッドでは既存の検索ロジックも冗長であったため修正を入れています。

- storeメソッドではracket登録時に規約に同意しているかを確認するためにフォームでagreementを用意してカスタムバリデーションで同意チェックを確認する処理を追加しています。

レビューお願いします。
