### PR TITLE
modify:#129:ユーザーがracket登録処理をできるように修正

### DIFF
--- a/app/Http/Controllers/RacketController.php
+++ b/app/Http/Controllers/RacketController.php
@@ -6,7 +6,9 @@ use Illuminate\Http\Request;
 use App\Models\Racket;
 use App\Http\Requests\Racket\RacketStoreRequest;
 use App\Http\Requests\Racket\RacketUpdateRequest;
+use App\Models\RacketImage;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
 
 class RacketController extends Controller
 {
@@ -44,16 +46,26 @@ class RacketController extends Controller
      * @param  \Illuminate\Http\Request  $request
      * @return \Illuminate\Http\Response
      */
-    public function store(RacketStoreRequest $request)
+    public function store(RacketStoreRequest $request, RacketImage $racketImageModel)
     {
         $validated = $request->validated();
 
         try {
-            $racket = Racket::create([
+            DB::beginTransaction();
+
+            // RacketImageモデルを使ってラケット画像を登録
+            $racketImage = $racketImageModel->registerRacketImage($validated);
+
+            $racket = Racket::with([
+                'maker',
+                'racketImage',
+                'user',
+                'series'
+            ])->create([
                 'name_ja' => $validated['name_ja'],
-                'name_en' => $validated['name_en'],
+                'name_en' => isset($validated['name_en']) ? $validated['name_en'] : '',
                 'maker_id' => $validated['maker_id'],
-                'image_id' => isset($validated['image_id']) ? $validated['image_id'] : null,
+                'image_id' => $racketImage->id,
                 'need_posting_image' => $validated['need_posting_image'],
                 'posting_user_id' => $validated['posting_user_id'],
                 'series_id' => isset($validated['series_id']) ? $validated['series_id'] : null,
@@ -63,10 +75,21 @@ class RacketController extends Controller
                 'balance' => isset($validated['balance']) ? $validated['balance'] : null,
             ]);
 
+            DB::commit();
+
+            
             if ($racket) {
-                return response()->json('ラケットを登録しました', 200);
+                $responseRacket = Racket::with([
+                    'maker',
+                    'racketImage',
+                    'user',
+                    'series',
+                ])->findOrFail($racket->id);
+                return response()->json($responseRacket, 200);
             }
         } catch (\Throwable $e) {
+            DB::rollBack();
+
             \Log::error($e);
 
             throw $e;

--- a/app/Http/Requests/GutReview/GutReviewStoreRequest.php
+++ b/app/Http/Requests/GutReview/GutReviewStoreRequest.php
@@ -35,19 +35,19 @@ class GutReviewStoreRequest extends FormRequest
             // 未登録のmy_equpipmentでレビューを投稿しようとした場合
             // gut_reviewと同時にmy_equipment新規登録するために使用
             'need_creating_my_equipment' => ['nullable', 'boolean'],
-            'user_height'       => ['nullable', 'string', 'max:20'],
-            'user_age'          => ['nullable', 'string', 'max:20'],
-            'experience_period' => ['nullable', 'integer'],
+            'user_height'       => ['required_if:need_creating_my_equipment,true', 'string', 'max:20'],
+            'user_age'          => ['required_if:need_creating_my_equipment,true', 'string', 'max:20'],
+            'experience_period' => ['required_if:need_creating_my_equipment,true', 'integer'],
 
-            'racket_id'         => ['nullable', 'integer', 'exists:rackets,id'],
-            'stringing_way'     => ['nullable', 'string', 'max:20'],
-            'main_gut_id'       => ['nullable', 'integer', 'exists:guts,id'],
-            'main_gut_guage'    => ['nullable', 'numeric',],
-            'main_gut_tension'  => ['nullable', 'integer'],
-            'cross_gut_id'      => ['nullable', 'integer', 'exists:guts,id'],
-            'cross_gut_guage'   => ['nullable', 'numeric',],
-            'cross_gut_tension' => ['nullable', 'integer'],
-            'new_gut_date'      => ['nullable', 'date'],
+            'racket_id'         => ['required_if:need_creating_my_equipment,true', 'integer', 'exists:rackets,id'],
+            'stringing_way'     => ['required_if:need_creating_my_equipment,true', 'string', 'max:20'],
+            'main_gut_id'       => ['required_if:need_creating_my_equipment,true', 'integer', 'exists:guts,id'],
+            'main_gut_guage'    => ['required_if:need_creating_my_equipment,true', 'numeric',],
+            'main_gut_tension'  => ['required_if:need_creating_my_equipment,true', 'integer'],
+            'cross_gut_id'      => ['required_if:need_creating_my_equipment,true', 'integer', 'exists:guts,id'],
+            'cross_gut_guage'   => ['required_if:need_creating_my_equipment,true', 'numeric',],
+            'cross_gut_tension' => ['required_if:need_creating_my_equipment,true', 'integer'],
+            'new_gut_date'      => ['required_if:need_creating_my_equipment,true', 'date'],
         ];
     }
 }

--- a/app/Http/Requests/Racket/RacketStoreRequest.php
+++ b/app/Http/Requests/Racket/RacketStoreRequest.php
@@ -38,6 +38,11 @@ class RacketStoreRequest extends FormRequest
             'weight' => ['nullable', 'integer', 'max:400'],
             'balance' => ['nullable', 'integer', 'max:400'],
             'agreement' => ['required', 'boolean', new AgreementConfirmation],
+            
+            // ラケット画像を同時に登録するため個別で必要
+            // maker_id, posting_user_idは共有
+            'file' => ['required', 'file', 'image', 'mimes:jpeg,png'],
+            'title' => ['required', 'max:30'],
         ];
     }
 }

--- a/app/Http/Requests/RacketImage/RacketImageStoreRequest.php
+++ b/app/Http/Requests/RacketImage/RacketImageStoreRequest.php
@@ -27,6 +27,7 @@ class RacketImageStoreRequest extends FormRequest
             'file' => ['required', 'file', 'image', 'mimes:jpeg,png'],
             'title' => ['required', 'max:30'],
             'maker_id' => ['required', 'integer', 'exists:makers,id'],
+            'posting_user_id' => ['required', 'integer', 'exists:users,id'],
         ];
     }
 }

--- a/app/Models/RacketImage.php
+++ b/app/Models/RacketImage.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Intervention\Image\Facades\Image;
 
 class RacketImage extends Model
 {
@@ -12,9 +13,11 @@ class RacketImage extends Model
     protected $fillable = [
         'file_path',
         'title',
-        'maker_id'
+        'maker_id',
+        'posting_user_id'
     ];
 
+    // dbリレーション関連メソッド
     public function rackets()
     {
         return $this->hasMany(Racket::class, 'image_id','id');
@@ -28,5 +31,47 @@ class RacketImage extends Model
     public function user()
     {
         return $this->belongsTo(User::class, 'posting_user_id', 'id');
+    }
+
+    // dbリクエスト処理関連
+
+    // ラケット画像登録処理
+    public function registerRacketImage($request)
+    {
+        // 画像ファイルリサイジング
+        $file = Image::make($request['file']);
+        $file->orientate();
+        $file->resize(
+            480,
+            null,
+            function ($constraint) {
+                // 縦横比を保持したままにする
+                $constraint->aspectRatio();
+                // 小さい画像は大きくしない
+                $constraint->upsize();
+            }
+        );
+
+        $filename = now()->format('YmdHis') . $request['title'] . "." . $request['file']->extension();
+
+        // storageに登録するためのpathを生成
+        $storagePath = storage_path('app/public/images/rackets');
+        $fileLocationFullPath = $storagePath . '/' . $filename;
+
+        if ($file->save($fileLocationFullPath)) {
+            // "/var/www/html/strii-backend/storage/app/public/images/rackets/20240105123954リサイズ確認５.jpg"
+            // intervension image導入前の登録の仕様に合わせるため
+            // 上記のようなfullPathをDBのfile_pathカラム用に整形
+            $trimedFilePath = strstr($fileLocationFullPath, 'images');
+
+            $racket_image = RacketImage::create([
+                'file_path' => $trimedFilePath,
+                'title' => $request['title'],
+                'maker_id' => $request['maker_id'],
+                'posting_user_id' => $request['posting_user_id'],
+            ]);
+        }
+
+        return $racket_image;
     }
 }


### PR DESCRIPTION
issue
#129

背景
ユーザーがラケットを登録する際にラケット画像も一緒に登録するため、RacketControllerのstoreメソッドでracket_imagesテーブルに画像を登録する処理をDBのtransitionを使って追加する必要がある

確認手順

- [ ] RacketControllerファイルを確認する
- [ ] storeメソッドにracket_imagesテーブルへの登録処理がないことが確認できる

やったこと

- [ ] Racketイメージ登録処理をRacketImageモデルに切り出し
- [ ] RacketControllerのstoreメソッドでracketイメージも同時に登録するようにRacketImageモデルを使って記載。dbのtransactionで登録処理を担保している
- [ ] イメージ登録処理をモデルに切り出したことによるRacketImageController、storeメソッドの修正
- [ ] racket登録時に画像も登録させる変更により生じた、Requestファイルの修正

備考
racketイメージ登録処理をモデルに切り出した時、publicメソッドとして切り出しているが、使用先でDIで引数として読み込んで使用しているところはstaticメソッドとして使用する方法も考えられるので要考察されたし

レビューお願いします。