### PR TITLE
add:dockerのdbコンテナでcsvファイルでデータを登録できる様に修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ yarn-error.log
 .DS_Store
 /docker/db/data/*
 /docker/ssl/jawsdb-ssl/*.pem
+/docker/csv/*.csv

--- a/docker-compose.develop.yml
+++ b/docker-compose.develop.yml
@@ -37,5 +37,6 @@ services:
       # - ./db/my.cnf:/etc/mysql/conf.d/my.cnf
       - ./docker/db/data:/var/lib/mysql
       - ./docker/db/my.cnf:/etc/mysql/conf.d/my.cnf
+      - ./docker/csv:/var/lib/mysql-files/csv
     ports:
       - 3306:3306

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,5 +39,6 @@ services:
       # - ./db/my.cnf:/etc/mysql/conf.d/my.cnf
       - ./docker/db/data:/var/lib/mysql
       - ./docker/db/my.cnf:/etc/mysql/conf.d/my.cnf
+      - ./docker/csv:/var/lib/mysql-files/csv
     ports:
       - 3306:3306

--- a/docker/db/my.cnf
+++ b/docker/db/my.cnf
@@ -4,6 +4,9 @@ collation-server=utf8mb4_general_ci
 explicit-defaults-for-timestamp=1
 general-log=1
 general-log-file=/var/log/mysql/mysqld.log
+local_infile=1
 
 [client]
 default-character-set=utf8mb4
+
+


### PR DESCRIPTION
### issue
#133 

### 背景
本番用に初期データを調査した際にデータの数が多いため、手動でDBに登録していくのは手間になる。集めたデータをcsvファイルとして扱いそれをDBに登録すれば一度に登録できる。

### 確認手順

- [ ] 用意したcsvファイルをコンテナのｄｂコンテナないで扱いたい
- [ ] docker-compose.ymlなどの設定ができていないためコンテナ内でcsvファイルを扱うことができないことが確認できる

修正後確認手順

- [ ] docker/csvフォルダに登録に使うcsvファイルを用意する（googleスプレッドシートからエクスポート）
- [ ] dbコンテナのbashに入る
- [ ] mysqlクライアントにログインする
- [ ] 下記の様なコマンドでcsvデータを登録すると成功する
ローカルのdockerコンテナで成功
LOAD DATA INFILE '/var/lib/mysql-files/csv/240220_strii_racket_series_list.csv'
INTO TABLE racket_series
FIELDS TERMINATED BY ','
ENCLOSED BY '"'
LINES TERMINATED BY '\n'
IGNORE 1 ROWS
(name_ja, name_en, maker_id)
SET created_at = NOW(), updated_at = NOW();


### やったこと

- [ ] csvファイルをコンテナ内で扱える様にcsvファイル群を扱うフォルダ（csv）を作成
- [ ] docker-compose.ymlでコンテナ内にマウントする様に記述
- [ ] マウント先はmysqlのセキュリティの関係で/var/lib/mysql-filesフォルダ内にマウント

### 備考
csvファイルを参照する権限をコンテナ内ユーザーに付与している。
本番でもこの方法でcsvファイルでデータを追加したかったが、herokuのjawsdbでこのcsvファイルでデータを登録する権限の付与ができなかったため、この方法はローカルでのみ有効である。本番環境へはlaravelのcsvファイルで登録する機能を実装して対応することとする。

レビューお願いします