### PR TITLE
add:  racket_seriesとgutをcsvファイルで登録する機能の実装

### DIFF
--- a/app/Http/Controllers/GutController.php
+++ b/app/Http/Controllers/GutController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Requests\Gut\GutStoreByCsvRequest;
 use App\Http\Requests\Gut\GutStoreRequest;
 use App\Http\Requests\Gut\GutUpdateRequest;
 use Illuminate\Http\Request;
@@ -226,5 +227,19 @@ class GutController extends Controller
             ->appends(['several_words' => $severalWords, 'maker' => $maker_id]);
 
         return response()->json($searchedGuts, 200);
+    }
+
+    // public function storeByCsv(Request $request)
+    public function storeByCsv(GutStoreByCsvRequest $request)
+    {
+        try {
+            Gut::storeByCsv($request);
+
+            return response()->json('csvデータを登録しました', 200);
+        } catch (\Throwable $e) {
+            \Log::error($e);
+
+            return $e;
+        }
     }
 }

--- a/app/Http/Controllers/RacketSeriesController.php
+++ b/app/Http/Controllers/RacketSeriesController.php
@@ -2,11 +2,14 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Requests\RacketSeriesRequests\RacketSeriesStoreByCsvRequest;
 use Illuminate\Http\Request;
 use App\Models\RacketSeries;
 
 use App\Http\Requests\RacketSeriesRequests\RacketSeriesStoreRequest;
 use App\Http\Requests\RacketSeriesRequests\RacketSeriesUpdateRequest;
+use Error;
+use Illuminate\Support\Facades\Validator;
 
 class RacketSeriesController extends Controller
 {
@@ -14,7 +17,7 @@ class RacketSeriesController extends Controller
     {
         $this->middleware('auth:admin')->only(['store', 'update', 'destroy']);
     }
-    
+
     /**
      * Display a listing of the resource.
      *
@@ -92,12 +95,12 @@ class RacketSeriesController extends Controller
             $racketSeries = RacketSeries::findOrFail($id);
 
             $racketSeries->name_ja = $validated_request['name_ja'];
-            
+
             if ($racketSeries->name_en) $racketSeries->name_en = $validated_request['name_en'];
 
             $racketSeries->maker_id = $validated_request['maker_id'];
 
-            if($racketSeries->save()) {
+            if ($racketSeries->save()) {
                 return response()->json([
                     'messages' => 'completed updating racketSeries',
                     'status' => 'ok'
@@ -108,7 +111,7 @@ class RacketSeriesController extends Controller
             throw $e;
         } catch (\Throwable $e) {
             \Log::error($e);
-            
+
             throw $e;
         }
     }
@@ -133,6 +136,63 @@ class RacketSeriesController extends Controller
             \Log::error($e);
 
             throw $e;
+        }
+    }
+
+    public function storeByCsv(RacketSeriesStoreByCsvRequest $request)
+    {
+        try {
+            if (!$request->hasFile('csv_file')) {
+                throw new Error('ファイルが存在しません');
+            }
+
+            // ファイルを取得
+            $csvFile = $request->file('csv_file');
+
+            // ファイルの拡張子をチェック
+            if ($csvFile->extension() !== 'csv') {
+                throw new Error('ファイルの形式が不正なものです');
+            }
+
+            // csvを配列に変換。
+            // file()はファイル全体を読み込んで配列に格納
+            // str_getcsvはphpの関数でCSV文字列をパースして配列に格納
+            $csvData = array_map('str_getcsv', file($csvFile));
+
+            // csvの一行目がデータでなくheaderなので$csvDataから抽出・削除
+            $header = array_shift($csvData);
+
+            $validatedCsvData = [];
+
+            // csvデータのバリデーションチェック
+            foreach ($csvData as $row) {
+                // array_combineでキーとバリューの連勝配列に変換し検証
+                $validator = Validator::make(array_combine($header, $row), RacketSeries::rules());
+
+                // バリデーションエラーがある場合の処理
+                if ($validator->fails()) {
+                    throw new Error($validator->errors());
+                }
+
+                array_push($validatedCsvData, $row);
+            }
+
+            // バリデーションを通過していれば登録
+            if ($validatedCsvData) {
+                foreach ($validatedCsvData as $data) {
+                    RacketSeries::create([
+                        'name_ja' => $data[0],
+                        'name_en' => $data[1],
+                        'maker_id' => $data[2],
+                    ]);
+                }
+
+                return response()->json('csvデータを登録しました', 200);
+            }
+        } catch (\Throwable $e) {
+            \Log::error($e);
+
+            return $e;
         }
     }
 }

--- a/app/Http/Controllers/RacketSeriesController.php
+++ b/app/Http/Controllers/RacketSeriesController.php
@@ -142,53 +142,9 @@ class RacketSeriesController extends Controller
     public function storeByCsv(RacketSeriesStoreByCsvRequest $request)
     {
         try {
-            if (!$request->hasFile('csv_file')) {
-                throw new Error('ファイルが存在しません');
-            }
+            RacketSeries::storeByCsv($request);
 
-            // ファイルを取得
-            $csvFile = $request->file('csv_file');
-
-            // ファイルの拡張子をチェック
-            if ($csvFile->extension() !== 'csv') {
-                throw new Error('ファイルの形式が不正なものです');
-            }
-
-            // csvを配列に変換。
-            // file()はファイル全体を読み込んで配列に格納
-            // str_getcsvはphpの関数でCSV文字列をパースして配列に格納
-            $csvData = array_map('str_getcsv', file($csvFile));
-
-            // csvの一行目がデータでなくheaderなので$csvDataから抽出・削除
-            $header = array_shift($csvData);
-
-            $validatedCsvData = [];
-
-            // csvデータのバリデーションチェック
-            foreach ($csvData as $row) {
-                // array_combineでキーとバリューの連勝配列に変換し検証
-                $validator = Validator::make(array_combine($header, $row), RacketSeries::rules());
-
-                // バリデーションエラーがある場合の処理
-                if ($validator->fails()) {
-                    throw new Error($validator->errors());
-                }
-
-                array_push($validatedCsvData, $row);
-            }
-
-            // バリデーションを通過していれば登録
-            if ($validatedCsvData) {
-                foreach ($validatedCsvData as $data) {
-                    RacketSeries::create([
-                        'name_ja' => $data[0],
-                        'name_en' => $data[1],
-                        'maker_id' => $data[2],
-                    ]);
-                }
-
-                return response()->json('csvデータを登録しました', 200);
-            }
+            return response()->json('csvデータを登録しました', 200);
         } catch (\Throwable $e) {
             \Log::error($e);
 

--- a/app/Http/Requests/Gut/GutStoreByCsvRequest.php
+++ b/app/Http/Requests/Gut/GutStoreByCsvRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Requests\Gut;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class GutStoreByCsvRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules()
+    {
+        return [
+            'csv_file' => ['required', 'file', 'mimes:csv'],
+        ];
+    }
+}

--- a/app/Http/Requests/RacketSeriesRequests/RacketSeriesStoreByCsvRequest.php
+++ b/app/Http/Requests/RacketSeriesRequests/RacketSeriesStoreByCsvRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Requests\RacketSeriesRequests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class RacketSeriesStoreByCsvRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules()
+    {
+        return [
+            'csv_file' => ['required', 'file', 'mimes:csv'],
+        ];
+    }
+}

--- a/app/Models/Gut.php
+++ b/app/Models/Gut.php
@@ -2,8 +2,11 @@
 
 namespace App\Models;
 
+use Error;
+use Exception;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Validator;
 
 class Gut extends Model
 {
@@ -16,6 +19,17 @@ class Gut extends Model
         'image_id',
         'need_posting_image'
     ];
+
+    public static function rules()
+    {
+        return [
+            'name_ja' => ['required', 'max:30'],
+            'name_en' => ['max:30'],
+            'maker_id' => ['required', 'integer', 'exists:makers,id'],
+            'image_id' => ['sometimes', 'integer', 'exists:gut_images,id'],
+            'need_posting_image' => ['required', 'boolean']
+        ];
+    }
 
     public function maker()
     {
@@ -35,5 +49,69 @@ class Gut extends Model
     public function myEquipmentsWithCrossGut()
     {
         return $this->hasMany(MyEquipment::class, 'cross_gut_id', 'id');
+    }
+
+
+    // csvファイルで登録
+    // csvファイルの一行目はheaderとして下記を想定
+    // 「name_ja,name_en,maker_id,image_id,need_posting_image」下記を想定
+    public static function storeByCsv($request)
+    {
+        if (!$request->hasFile('csv_file')) {
+            throw new Error('ファイルが存在しません');
+        }
+
+        // ファイルを取得
+        $csvFile = $request->file('csv_file');
+
+        // ファイルの拡張子をチェック
+        if ($csvFile->extension() !== 'csv') {
+            throw new Exception('ファイルの形式が不正なものです');
+        }
+
+        // csvを配列に変換。
+        // file()はファイル全体を読み込んで配列に格納
+        // str_getcsvはphpの関数でCSV文字列をパースして配列に格納
+        $csvData = array_map('str_getcsv', file($csvFile));
+
+        // csvの一行目がデータでなくheaderなので$csvDataから抽出・削除
+        $header = array_shift($csvData);
+
+        $validatedCsvData = [];
+
+        $errors = [];
+
+        // csvデータのバリデーションチェック
+        foreach ($csvData as $row) {
+            // array_combineでキーとバリューの連勝配列に変換し検証
+            // $validator = Validator::make(array_combine($header, $row), RacketSeries::rules());
+            $validator = Validator::make(array_combine($header, $row), self::rules());
+
+            // バリデーションエラーがある場合の処理
+            if ($validator->fails()) {
+                $errors = $validator->errors();
+                $errorHeader = "[{$header[0]},{$header[1]},{$header[2]},{$header[3]},{$header[4]}]";
+                $errorRow = "[{$row[0]},{$row[1]},{$row[2]},{$row[3]},{$row[4]}]";
+
+                throw new Exception(
+                    "{$errorHeader}{$errorRow}:{$errors}"
+                );
+            }
+
+            array_push($validatedCsvData, $row);
+        }
+
+        // バリデーションを通過していれば登録
+        if ($validatedCsvData) {
+            foreach ($validatedCsvData as $data) {
+                Gut::create([
+                    'name_ja' => $data[0],
+                    'name_en' => $data[1],
+                    'maker_id' => $data[2],
+                    'image_id' => $data[3],
+                    'need_posting_image' => $data[4] ? $data[4] : true,
+                ]);
+            }
+        }
     }
 }

--- a/app/Models/RacketSeries.php
+++ b/app/Models/RacketSeries.php
@@ -4,6 +4,8 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Error;
+use Illuminate\Support\Facades\Validator;
 
 class RacketSeries extends Model
 {
@@ -32,5 +34,58 @@ class RacketSeries extends Model
     public function maker()
     {
         return $this->belongsTo(Maker::class);
+    }
+
+    public static function storeByCsv($request)
+    {
+        if (!$request->hasFile('csv_file')) {
+            throw new Error('ファイルが存在しません');
+        }
+
+        // ファイルを取得
+        $csvFile = $request->file('csv_file');
+
+        // ファイルの拡張子をチェック
+        if ($csvFile->extension() !== 'csv') {
+            throw new Error('ファイルの形式が不正なものです');
+        }
+
+        // csvを配列に変換。
+        // file()はファイル全体を読み込んで配列に格納
+        // str_getcsvはphpの関数でCSV文字列をパースして配列に格納
+        $csvData = array_map('str_getcsv', file($csvFile));
+
+        // csvの一行目がデータでなくheaderなので$csvDataから抽出・削除
+        $header = array_shift($csvData);
+
+        $validatedCsvData = [];
+
+        $errors = [];
+
+        // csvデータのバリデーションチェック
+        foreach ($csvData as $row) {
+            // array_combineでキーとバリューの連勝配列に変換し検証
+            $validator = Validator::make(array_combine($header, $row), RacketSeries::rules());
+
+            // バリデーションエラーがある場合の処理
+            if ($validator->fails()) {
+                $errors = $validator->errors();
+                
+                throw new Error("[{$header[0]},{$header[1]},{$header[2]}][{$row[0]},{$row[1]},{$row[2]}]:{$errors}");
+            }
+
+            array_push($validatedCsvData, $row);
+        }
+
+        // バリデーションを通過していれば登録
+        if ($validatedCsvData) {
+            foreach ($validatedCsvData as $data) {
+                RacketSeries::create([
+                    'name_ja' => $data[0],
+                    'name_en' => $data[1],
+                    'maker_id' => $data[2],
+                ]);
+            }
+        }
     }
 }

--- a/app/Models/RacketSeries.php
+++ b/app/Models/RacketSeries.php
@@ -15,6 +15,15 @@ class RacketSeries extends Model
         'maker_id',
     ];
 
+    public static function rules()
+    {
+        return [
+            'name_ja' => ['required', 'string', 'max:30'],
+            'name_en' => ['string', 'max:30'],
+            'maker_id' => ['required', 'integer', 'exists:makers,id'],
+        ];
+    }
+
     public function rackets()
     {
         return $this->hasMany(Racket::class, 'series_id', 'id');

--- a/routes/web.php
+++ b/routes/web.php
@@ -35,6 +35,7 @@ Route::get('/', function () {
 
 Route::apiResource('api/makers', MakerController::class);
 
+Route::post('api/racket_series/upload_csv', [RacketSeriesController::class, 'storeByCsv']);
 Route::apiResource('api/racket_series', RacketSeriesController::class);
 
 Route::get('api/gut_images/search', [GutImageController::class, 'gutImageSearch']);

--- a/routes/web.php
+++ b/routes/web.php
@@ -44,6 +44,7 @@ Route::apiResource('api/gut_images', GutImageController::class);
 Route::get('api/racket_images/search', [RacketImageController::class, 'racketImageSearch']);
 Route::apiResource('api/racket_images', RacketImageController::class);
 
+Route::post('api/guts/upload_csv', [GutController::class, 'storeByCsv']);
 Route::get('api/guts/search', [GutController::class, 'gutSearch']);
 Route::apiResource('api/guts', GutController::class);
 Route::get('api/guts/{id}/others', [GutController::class, 'getRandamOtherGuts']);


### PR DESCRIPTION
### issue
#135 

### 背景
サイトの初期データの数が多数あるので直接入力でデータを登録すると時間的にも手間であるのでcsvファイルで一括で登録したい

### 確認手順

- [ ] 調査してあったラケットシリーズを登録しようとする

- [ ] 数が多いので手動で登録するには時間がかかる

- [ ] 調査してあったストリングを登録しようとする

- [ ] 数が多いので手動で登録するには時間がかかる

### やったこと

- [ ] racket_seriesをcsvファイルで登録する機能をRacketSeriesControllerにstoreByCsvメソッドとして実装
- [ ] RacketSeriesControllerに作成したstoreByCsvメソッドをRacketSeriesモデルファイルに切り出し
- [ ] 同様にしてgutsをcsvファイルで登録する機能をGutControllerのstoreByCsvメソッドを作成し実装

### 備考
想定するcsvファイルでは一行目をテーブルのカラムと対応するheaderとしてcsvファイルを作成してある必要がある

レビューお願いします。