### PR TITLE
add:gutsテーブルにguage, categoryカラムを追加

### DIFF
--- a/app/Http/Controllers/GutController.php
+++ b/app/Http/Controllers/GutController.php
@@ -196,32 +196,42 @@ class GutController extends Controller
 
         $maker_id = $request->query('maker');
 
+        $guage = $request->query('guage');
+
+        $category = $request->query('category');
+
         $gutQuery = Gut::query();
 
-        if ($severalWords && $maker_id) {
-            foreach ($severalWordsArray as $word) {
-                //severalWordsで複数取れてきてもmakerが一致しない場合は弾かれる
-                $gutQuery
-                    ->orWhere(function ($gutQuery) use ($word, $maker_id) {
-                        $gutQuery
-                            ->where(function ($gutQuery) use ($word) {
-                                $gutQuery
-                                    ->orWhere('name_ja', 'like', '%' . $word . '%')
-                                    ->orWhere('name_en', 'like', '%' . $word . '%');
-                            })
-                            ->where('maker_id', '=', $maker_id);
-                    });
-            }
-        } elseif ($severalWords && empty($maker_id)) {
-            //makerの指定がないのでseveralWordsのor検索となる
-            foreach ($severalWordsArray as $word) {
-                $gutQuery
-                    ->orWhere('name_ja', 'like', '%' . $word . '%')
-                    ->orWhere('name_en', 'like', '%' . $word . '%');
-            }
-        } elseif (empty($severalWords) && $maker_id) {
-            //makerのみでの検索
-            $gutQuery->where('maker_id', '=', $maker_id);
+        // 太さguageで検索
+        if($guage) {
+            $gutQuery->where(function ($gutQuery) use ($guage) {
+                $gutQuery->where('guage', 'like', "%{$guage}%");
+            });
+        }
+
+        // gutカテゴリーで検索
+        if($category) {
+            $gutQuery->where(function ($gutQuery) use ($category) {
+                $gutQuery->where('category', '=', $category);
+            });
+        }
+
+        // メーカーで検索
+        if ($maker_id) {
+            $gutQuery->where(function ($gutQuery) use ($maker_id) {
+                $gutQuery->where('maker_id', '=', $maker_id);
+            });
+        }
+
+        // キーワード検索
+        if ($severalWords) {
+            $gutQuery->where(function ($gutQuery) use ($severalWordsArray) {
+                foreach ($severalWordsArray as $word) {
+                    $gutQuery
+                        ->orWhere('name_ja', 'like', '%' . $word . '%')
+                        ->orWhere('name_en', 'like', '%' . $word . '%');
+                }
+            });
         }
 
         $searchedGuts = $gutQuery
@@ -232,7 +242,6 @@ class GutController extends Controller
         return response()->json($searchedGuts, 200);
     }
 
-    // public function storeByCsv(Request $request)
     public function storeByCsv(GutStoreByCsvRequest $request)
     {
         try {

--- a/app/Http/Controllers/GutController.php
+++ b/app/Http/Controllers/GutController.php
@@ -55,6 +55,8 @@ class GutController extends Controller
                 'maker_id' => $validated['maker_id'],
                 'image_id' => isset($validated['image_id']) ? $validated['image_id'] : $defaultgutImage->id,
                 'need_posting_image' => $validated['need_posting_image'],
+                'guage' => isset($validated['guage']) ? $validated['guage'] : '',
+                'category' => isset($validated['category']) ? $validated['category'] : '',
             ]);
 
             if ($gut) {
@@ -99,16 +101,17 @@ class GutController extends Controller
     {
         $validated = $request->validated();
 
-        
-
         try {
             $gut = Gut::findOrFail($id);
 
             $gut->name_ja = $validated['name_ja'];
             $gut->name_en = $validated['name_en'];
             $gut->maker_id = $validated['maker_id'];
-            $gut->image_id = isset($validated['image_id']) ? $validated['image_id'] : null;
+            $gut->image_id = isset($validated['image_id']) ? $validated['image_id'] : $gut->image_id;
             $gut->need_posting_image = $validated['need_posting_image'];
+            $gut->guage = isset($validated['guage']) ? $validated['guage'] : $gut->guage;
+            $gut->category = isset($validated['category']) ? $validated['category'] : $gut->category;
+
             if ($gut->save()) {
                 return response()->json('ガット情報を更新しました', 200);
             }

--- a/app/Http/Requests/Gut/GutStoreRequest.php
+++ b/app/Http/Requests/Gut/GutStoreRequest.php
@@ -28,7 +28,9 @@ class GutStoreRequest extends FormRequest
             'name_en' => ['max:30'],
             'maker_id' => ['required', 'integer', 'exists:makers,id'],
             'image_id' => ['sometimes', 'integer', 'exists:gut_images,id'],
-            'need_posting_image' => ['required','boolean']
+            'need_posting_image' => ['required','boolean'],
+            'guage' => ['max:30'],
+            'category' => ['max:30']
         ];
     }
 }

--- a/app/Http/Requests/Gut/GutUpdateRequest.php
+++ b/app/Http/Requests/Gut/GutUpdateRequest.php
@@ -28,7 +28,9 @@ class GutUpdateRequest extends FormRequest
             'name_en' => ['max:30'],
             'maker_id' => ['required', 'integer', 'exists:makers,id'],
             'image_id' => ['sometimes', 'integer', 'exists:gut_images,id'],
-            'need_posting_image' => ['required','boolean']
+            'need_posting_image' => ['required','boolean'],
+            'guage' => ['max:30'],
+            'category' => ['max:30'],
         ];
     }
 }

--- a/app/Models/Gut.php
+++ b/app/Models/Gut.php
@@ -17,7 +17,9 @@ class Gut extends Model
         'name_en',
         'maker_id',
         'image_id',
-        'need_posting_image'
+        'need_posting_image',
+        'guage',
+        'category'
     ];
 
     public static function rules()

--- a/app/Models/Gut.php
+++ b/app/Models/Gut.php
@@ -29,7 +29,9 @@ class Gut extends Model
             'name_en' => ['max:30'],
             'maker_id' => ['required', 'integer', 'exists:makers,id'],
             'image_id' => ['sometimes', 'integer', 'exists:gut_images,id'],
-            'need_posting_image' => ['required', 'boolean']
+            'need_posting_image' => ['required', 'boolean'],
+            'guage' => ['max:30'],
+            'category' => ['max:30'],
         ];
     }
 
@@ -56,7 +58,7 @@ class Gut extends Model
 
     // csvファイルで登録
     // csvファイルの一行目はheaderとして下記を想定
-    // 「name_ja,name_en,maker_id,image_id,need_posting_image」下記を想定
+    // 「name_ja,name_en,maker_id,image_id,need_posting_image,guage,category」
     public static function storeByCsv($request)
     {
         if (!$request->hasFile('csv_file')) {
@@ -86,14 +88,13 @@ class Gut extends Model
         // csvデータのバリデーションチェック
         foreach ($csvData as $row) {
             // array_combineでキーとバリューの連勝配列に変換し検証
-            // $validator = Validator::make(array_combine($header, $row), RacketSeries::rules());
             $validator = Validator::make(array_combine($header, $row), self::rules());
 
             // バリデーションエラーがある場合の処理
             if ($validator->fails()) {
                 $errors = $validator->errors();
-                $errorHeader = "[{$header[0]},{$header[1]},{$header[2]},{$header[3]},{$header[4]}]";
-                $errorRow = "[{$row[0]},{$row[1]},{$row[2]},{$row[3]},{$row[4]}]";
+                $errorHeader = "[{$header[0]},{$header[1]},{$header[2]},{$header[3]},{$header[4]},{$header[5]},{$header[6]}]";
+                $errorRow = "[{$row[0]},{$row[1]},{$row[2]},{$row[3]},{$row[4]},{$row[5]},{$row[6]}]";
 
                 throw new Exception(
                     "{$errorHeader}{$errorRow}:{$errors}"
@@ -112,6 +113,8 @@ class Gut extends Model
                     'maker_id' => $data[2],
                     'image_id' => $data[3],
                     'need_posting_image' => $data[4] ? $data[4] : true,
+                    'guage' => $data[5] ? $data[5] : '',
+                    'category' => $data[6] ? $data[6] : '',
                 ]);
             }
         }

--- a/database/migrations/2024_02_28_165308_add_columns_guage_and_category_to_guts_table.php
+++ b/database/migrations/2024_02_28_165308_add_columns_guage_and_category_to_guts_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('guts', function (Blueprint $table) {
+            $table->string('guage', 30)->nullable()->default('')->after('need_posting_image');
+            $table->string('category', 30)->nullable()->default('')->after('guage');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('guts', function (Blueprint $table) {
+            $table->dropColumn('guage');
+            $table->dropColumn('category');
+        });
+    }
+};

--- a/database/seeders/GutSeeder.php
+++ b/database/seeders/GutSeeder.php
@@ -23,6 +23,8 @@ class GutSeeder extends Seeder
                 'maker_id' => 2,
                 'image_id' => 1,
                 'need_posting_image' => true,
+                'guage' => '1.15/1.20/1.25/1.30',
+                'category' => 'ポリエステル',
                 'created_at' => Carbon::now(),
                 'updated_at' => Carbon::now()
             ],
@@ -32,6 +34,8 @@ class GutSeeder extends Seeder
                 'maker_id' => 5,
                 'image_id' => 1,
                 'need_posting_image' => true,
+                'guage' => '1.20/1.25/1.30/1.35',
+                'category' => 'ポリエステル',
                 'created_at' => Carbon::now(),
                 'updated_at' => Carbon::now()
             ],
@@ -41,6 +45,8 @@ class GutSeeder extends Seeder
                 'maker_id' => 5,
                 'image_id' => 1,
                 'need_posting_image' => true,
+                'guage' => '1.20/1.25/1.30',
+                'category' => 'ポリエステル',
                 'created_at' => Carbon::now(),
                 'updated_at' => Carbon::now()
             ],
@@ -50,6 +56,8 @@ class GutSeeder extends Seeder
                 'maker_id' => 4,
                 'image_id' => 1,
                 'need_posting_image' => true,
+                'guage' => '1.30',
+                'category' => 'ポリエステル',
                 'created_at' => Carbon::now(),
                 'updated_at' => Carbon::now()
             ],
@@ -59,6 +67,8 @@ class GutSeeder extends Seeder
                 'maker_id' => 3,
                 'image_id' => 1,
                 'need_posting_image' => true,
+                'guage' => '1.25/1.30',
+                'category' => 'ポリエステル',
                 'created_at' => Carbon::now(),
                 'updated_at' => Carbon::now()
             ],
@@ -68,6 +78,8 @@ class GutSeeder extends Seeder
                 'maker_id' => 2,
                 'image_id' => 1,
                 'need_posting_image' => true,
+                'guage' => '1.20/1.25/1.30',
+                'category' => 'ポリエステル',
                 'created_at' => Carbon::now(),
                 'updated_at' => Carbon::now()
             ],
@@ -77,6 +89,8 @@ class GutSeeder extends Seeder
                 'maker_id' => 13,
                 'image_id' => 1,
                 'need_posting_image' => true,
+                'guage' => '1.10/1.15/1.20/1.25/1.30',
+                'category' => 'ポリエステル',
                 'created_at' => Carbon::now(),
                 'updated_at' => Carbon::now()
             ],
@@ -86,6 +100,8 @@ class GutSeeder extends Seeder
                 'maker_id' => 13,
                 'image_id' => 1,
                 'need_posting_image' => true,
+                'guage' => '1.25/1.30',
+                'category' => 'ポリエステル',
                 'created_at' => Carbon::now(),
                 'updated_at' => Carbon::now()
             ],
@@ -95,6 +111,8 @@ class GutSeeder extends Seeder
                 'maker_id' => 1,
                 'image_id' => 1,
                 'need_posting_image' => true,
+                'guage' => '1.30',
+                'category' => 'ナチュラル',
                 'created_at' => Carbon::now(),
                 'updated_at' => Carbon::now()
             ],


### PR DESCRIPTION
### issue
#138 

### 背景
gutについて扱う情報でそのガットの選べる太さとガットの種類（材質や構造を示す）を扱う必要が出てきたのでguageとcategoryカラムを追加する

### 確認手順

- [ ] googleスプレッドシートの仕様書の調査データのガットの情報を確認する
- [ ] gutの情報としてguageとcategoryカラムが必要になることがわかる

### やったこと

- [ ] gutsテーブルにguageとcategoryカラムを追加
- [ ] カラムを追加したことによるstore,updateメソッドの修正
- [ ] カラム追加によるcsvでの登録処理のstoreByCsvメソッドを修正
- [ ] カラム追加によるgutSearchメソッドの修正

### 備考

- gutSearchで既存の記述を少しリファクタリングしている。
- csvファイルのカラムの順番が登録処理に関係しているので注意されたし

レビューお願いします
