### PR TITLE
modify:フロントの画像表示変更に伴うgutImage返却データの修正

### DIFF
--- a/app/Http/Controllers/MyEquipmentController.php
+++ b/app/Http/Controllers/MyEquipmentController.php
@@ -25,7 +25,12 @@ class MyEquipmentController extends Controller
     public function index()
     {
         try {
-            $my_equipment = MyEquipment::with(['user', 'mainGut', 'crossGut'])->paginate(8);
+            $my_equipment = MyEquipment::with([
+                'user',
+                'racket' => ['maker', 'racketImage'],
+                'mainGut' => ['maker', 'gutImage'],
+                'crossGut' => ['maker', 'gutImage']
+            ])->paginate(8);
 
             return response()->json($my_equipment, 200);
         } catch (\Throwable $e) {

--- a/database/seeders/GutImageSeeder.php
+++ b/database/seeders/GutImageSeeder.php
@@ -19,7 +19,7 @@ class GutImageSeeder extends Seeder
     {
         DB::table('gut_images')->insert([
             [
-                'file_path' => 'images/guts/default_gut_image.jpg',
+                'file_path' => 'images/guts/default_gut_image.png',
                 'title' => 'デフォルト',
                 'maker_id' => null,
                 'created_at' => Carbon::now(),


### PR DESCRIPTION
### issue
#140 

### 背景
本番で使う画像を表示させるためにフロントエンドでコードを編集した際にbackendのコードの修正必要となったため修正

### 確認手順

- [ ] GutImageSeederのgutイメージのデフォルト画像pathが.jpgとなっており、想定は.pngであるのを確認する
- [ ] また、MyEquipmentControllerのindexメソッドで返却されるデータのeager loadingにracket情報がない

### やったこと

- [ ] MyEquipmentControllerのindexメソッドで返却されるデータのeager loadingにracketを追加
- [ ] GutImageSeederのgutイメージのデフォルト画像pathをdefault_gut_image**.jpg**からdefault_gut_image**.png**に変更

### 備考
フロントでの表示のために変更している

レビューお願いします