### PR TITLE
fix:#145:コンテナアタッチ時のartisanコマンド及びリクエストのpending状態を解消

### DIFF
--- a/docker/php/php.ini
+++ b/docker/php/php.ini
@@ -1978,7 +1978,7 @@ ldap.max_links = -1
 
 [xdebug]
 xdebug.mode=debug
-xdebug.start_with_request = yes
+; xdebug.start_with_request=yes
 xdebug.client_host=host.docker.internal
 xdebug.client_port=9003
 xdebug.discover_client_host = 1


### PR DESCRIPTION
### 背景
今までコンテナアタッチ先でphp artisanコマンドの処理およびpostmanとフロントからのリクエストは正常に処理されていたが、突然コンテナアタッチ先のvscode上でphp artisanコマンドの処理が進まなくなり、またpostmanおよびフロントからのリクエストがpending状態で進まなくなってしまった。これを解消したい

### 確認手順
dev containersでアタッチ時
- [ ] バックエンドのdockerコンテナを立ち上げる
- [ ] コンテナ内にvscode拡張機能のdev containersを使ってアタッチして入る
- [ ] アタッチ先のvscode上のターミナルでphp artisanコマンドをどれか実行してみる（php artisan listなど）
- [ ] 処理が進まずまたエラー表示などもない状態が続いてしまうことが確認できる
- [ ] さらにpostman及びフロントから何かリクエストを投げる
- [ ] 処理が進まずpending状態となることが確認できる（chrome解析ツールのnetworkタブからも確認できる）

dev containerを使わずdocker execコマンドでコンテナに入った時

- [ ] php artisan listコマンドを実行する
- [ ] 正常に処理が進む
- [ ] postman及びフロントからリクエストを送る
- [ ] 正常に処理が進む


### 備考１
原因がxdebugの挙動によるものだと調査で見当をつけた。理由としては

- php.iniに記載していたxdebugを無効にすると正常にコマンドとリクエストが処理されることを確認
- php.iniのxdebugの設定で『xdebug.start_with_request=yes』のみをコメントアウトするとxdebug有効下でもphp artisanコマンドと各種リクエストが正常に処理された


### やったこと

- [ ] php.iniのxdebugの設定で『xdebug.start_with_request=yes』をコメントアウト

### 備考２
上記の修正でxdebugでのデバッギングがvscodeのブレイクポイントで止まらなくなる不具合が生じた。
これを解消するために試行錯誤した結果、vscodeのブレイクポイントを置くのではなくコード上に直接『xdebug_break();』を記載することで今まで通りにxdebugを使用したデバッギングが行える状態になったので注意されたいし

### 解決までに試したこと

- dev containersの何かが原因であると考えvscodeのバージョンを下げたが解決しなかった


レビューお願いします