### PR TITLE
modify:racket画像保存先をamazon　s3に変更

### DIFF
--- a/app/Http/Controllers/RacketImageController.php
+++ b/app/Http/Controllers/RacketImageController.php
@@ -9,6 +9,7 @@ use App\Models\Maker;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Storage;
 use Intervention\Image\Facades\Image;
+use Exception;
 
 class RacketImageController extends Controller
 {
@@ -53,7 +54,7 @@ class RacketImageController extends Controller
 
                 return response()->json([
                     'id' => $racket_image['id'],
-                    'file_path' => Storage::url($racket_image['file_path']),
+                    'file_path' => $racket_image['file_path'],
                     'title' => $racket_image['title'],
                     'maker' => $maker,
                     'posting_user_id' => $racket_image['posting_user_id']
@@ -106,7 +107,7 @@ class RacketImageController extends Controller
         try {
             $image = RacketImage::with('maker')->findOrFail($id);
 
-            //新しいファイルがあれば新たにstorageに登録
+            //新しいファイルがあれば新たにs3へアップロードする
             if ($request->file('file')) {
                 // 画像ファイルリサイジング
                 $file = Image::make($request->file('file'));
@@ -123,21 +124,34 @@ class RacketImageController extends Controller
                 );
 
                 $filename = now()->format('YmdHis') . $validated_request['title'] . "." . $request->file('file')->extension();
-
-                // storageに登録するためのpathを生成
+                
+                // storageに一時的に登録するためのpathを生成
                 $storagePath = storage_path('app/public/images/rackets');
                 $fileLocationFullPath = $storagePath . '/' . $filename;
 
                 if ($file->save($fileLocationFullPath)) {
-                    // "/var/www/html/strii-backend/storage/app/public/images/rackets/20240105123954リサイズ確認５.jpg"
-                    // intervension image導入前の登録の仕様に合わせるため
-                    // 上記のようなfullPathをDBのfile_pathカラム用に整形
-                    $trimedFilePath = strstr($fileLocationFullPath, 'images');
+                    // 画像をAmazon S3にアップロード用urlに整形
+                    $filePath = 'images/rackets/' . $filename;
 
-                    //以前のイメージファイルをstorageフォルダから削除
-                    Storage::disk('public')->delete($image->file_path);
+                    // s3へアップロード
+                    if (Storage::disk('s3')->put($filePath, file_get_contents($fileLocationFullPath))) {
+                        // 成功時
+                        // S3上の画像のURLを取得
+                        $s3Url = Storage::disk('s3')->url($filePath);
 
-                    $image->file_path = $trimedFilePath;
+                        // 以前のpathを保管しておく
+                        $previousFilePath = $image->file_path;
+                        
+                        // 更新用の新しいurlを格納
+                        $image->file_path = $s3Url;
+
+                    } else {
+                        // 失敗時
+                        // 一時保存していたファイルを削除
+                        unlink($fileLocationFullPath);
+
+                        throw new Exception('s3への画像アップロードに失敗しました');
+                    }
                 }
             }
 
@@ -145,17 +159,33 @@ class RacketImageController extends Controller
             $image->maker_id = $validated_request['maker_id'];
 
             if ($image->save()) {
+                if($request->file('file') && $s3Url) {
+                    // s3上の以前の画像を削除(strstr()はurlの整形)
+                    $trimedFilePath = strstr($previousFilePath, 'images');
+                    Storage::disk('s3')->delete($trimedFilePath);
+                    unlink($fileLocationFullPath);
+                }
+                
                 $maker = Maker::find($image->maker_id);
 
                 return response()->json([
                     'id' => $image['id'],
-                    'file_path' => Storage::url($image['file_path']),
+                    'file_path' => $image['file_path'],
                     'title' => $image['title'],
                     'maker' => $maker
                 ], 200);
+            } else {
+                throw new Exception('画像情報更新に失敗しました');
             }
         } catch (\Throwable $e) {
             \Log::error($e);
+
+            // s3に更新アップロードしていた場合は削除してclean up
+            if($request->file('file') && $s3Url && Storage::disk('s3')->exists($trimedFilePath)) {
+                Storage::disk('s3')->delete($trimedFilePath);
+
+                unlink($fileLocationFullPath);
+            }
 
             throw $e;
         }
@@ -172,11 +202,18 @@ class RacketImageController extends Controller
         try {
             $image = RacketImage::findOrFail($id);
 
-            Storage::disk('public')->delete($image->file_path);
+            // file_pathが下記の様に登録してある
+            // https://strii-bucket.s3.ap-northeast-1.amazonaws.com/images/rackets/20240313003254〜〜〜.jpg
+            // これを『images/rackets/20240313003254〜〜〜.jpg』の様に整形する
+            $trimedFilePath = strstr($image->file_path, 'images');
 
-            $image->delete();
+            if (Storage::disk('s3')->delete($trimedFilePath)) {
+                $image->delete();
 
-            return response()->json("{$image['title']}の画像を削除しました", 200);
+                return response()->json("{$image['title']}の画像を削除しました", 200);
+            } else {
+                throw new Exception("画像の削除に失敗しました");
+            }
         } catch (ModelNotFoundException $e) {
             throw $e;
         } catch (\Throwable $e) {

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
         "intervention/image": "2.7.2",
         "laravel/framework": "^9.19",
         "laravel/sanctum": "^3.0",
-        "laravel/tinker": "^2.7"
+        "laravel/tinker": "^2.7",
+        "league/flysystem-aws-s3-v3": "^3.24"
     },
     "require-dev": {
         "fakerphp/faker": "^1.9.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,157 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8bcabefec5394df1a114d43ae0186774",
+    "content-hash": "47f2d4b78adf1d963672c04bd7330e70",
     "packages": [
+        {
+            "name": "aws/aws-crt-php",
+            "version": "v1.2.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/awslabs/aws-crt-php.git",
+                "reference": "eb0c6e4e142224a10b08f49ebf87f32611d162b2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/awslabs/aws-crt-php/zipball/eb0c6e4e142224a10b08f49ebf87f32611d162b2",
+                "reference": "eb0c6e4e142224a10b08f49ebf87f32611d162b2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35||^5.6.3||^9.5",
+                "yoast/phpunit-polyfills": "^1.0"
+            },
+            "suggest": {
+                "ext-awscrt": "Make sure you install awscrt native extension to use any of the functionality."
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "AWS SDK Common Runtime Team",
+                    "email": "aws-sdk-common-runtime@amazon.com"
+                }
+            ],
+            "description": "AWS Common Runtime for PHP",
+            "homepage": "https://github.com/awslabs/aws-crt-php",
+            "keywords": [
+                "amazon",
+                "aws",
+                "crt",
+                "sdk"
+            ],
+            "support": {
+                "issues": "https://github.com/awslabs/aws-crt-php/issues",
+                "source": "https://github.com/awslabs/aws-crt-php/tree/v1.2.4"
+            },
+            "time": "2023-11-08T00:42:13+00:00"
+        },
+        {
+            "name": "aws/aws-sdk-php",
+            "version": "3.300.16",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/aws/aws-sdk-php.git",
+                "reference": "d6afaeaa0c0e2c3be5f5223f72c0b5e2b2667b67"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/d6afaeaa0c0e2c3be5f5223f72c0b5e2b2667b67",
+                "reference": "d6afaeaa0c0e2c3be5f5223f72c0b5e2b2667b67",
+                "shasum": ""
+            },
+            "require": {
+                "aws/aws-crt-php": "^1.2.3",
+                "ext-json": "*",
+                "ext-pcre": "*",
+                "ext-simplexml": "*",
+                "guzzlehttp/guzzle": "^6.5.8 || ^7.4.5",
+                "guzzlehttp/promises": "^1.4.0 || ^2.0",
+                "guzzlehttp/psr7": "^1.9.1 || ^2.4.5",
+                "mtdowling/jmespath.php": "^2.6",
+                "php": ">=7.2.5",
+                "psr/http-message": "^1.0 || ^2.0"
+            },
+            "require-dev": {
+                "andrewsville/php-token-reflection": "^1.4",
+                "aws/aws-php-sns-message-validator": "~1.0",
+                "behat/behat": "~3.0",
+                "composer/composer": "^1.10.22",
+                "dms/phpunit-arraysubset-asserts": "^0.4.0",
+                "doctrine/cache": "~1.4",
+                "ext-dom": "*",
+                "ext-openssl": "*",
+                "ext-pcntl": "*",
+                "ext-sockets": "*",
+                "nette/neon": "^2.3",
+                "paragonie/random_compat": ">= 2",
+                "phpunit/phpunit": "^5.6.3 || ^8.5 || ^9.5",
+                "psr/cache": "^1.0",
+                "psr/simple-cache": "^1.0",
+                "sebastian/comparator": "^1.2.3 || ^4.0",
+                "yoast/phpunit-polyfills": "^1.0"
+            },
+            "suggest": {
+                "aws/aws-php-sns-message-validator": "To validate incoming SNS notifications",
+                "doctrine/cache": "To use the DoctrineCacheAdapter",
+                "ext-curl": "To send requests using cURL",
+                "ext-openssl": "Allows working with CloudFront private distributions and verifying received SNS messages",
+                "ext-sockets": "To use client-side monitoring"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "Aws\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Amazon Web Services",
+                    "homepage": "http://aws.amazon.com"
+                }
+            ],
+            "description": "AWS SDK for PHP - Use Amazon Web Services in your PHP project",
+            "homepage": "http://aws.amazon.com/sdkforphp",
+            "keywords": [
+                "amazon",
+                "aws",
+                "cloud",
+                "dynamodb",
+                "ec2",
+                "glacier",
+                "s3",
+                "sdk"
+            ],
+            "support": {
+                "forum": "https://forums.aws.amazon.com/forum.jspa?forumID=80",
+                "issues": "https://github.com/aws/aws-sdk-php/issues",
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.300.16"
+            },
+            "time": "2024-03-12T18:04:55+00:00"
+        },
         {
             "name": "brick/math",
             "version": "0.11.0",
@@ -2070,6 +2219,71 @@
             "time": "2023-10-20T17:59:40+00:00"
         },
         {
+            "name": "league/flysystem-aws-s3-v3",
+            "version": "3.24.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/flysystem-aws-s3-v3.git",
+                "reference": "809474e37b7fb1d1f8bcc0f8a98bc1cae99aa513"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/flysystem-aws-s3-v3/zipball/809474e37b7fb1d1f8bcc0f8a98bc1cae99aa513",
+                "reference": "809474e37b7fb1d1f8bcc0f8a98bc1cae99aa513",
+                "shasum": ""
+            },
+            "require": {
+                "aws/aws-sdk-php": "^3.295.10",
+                "league/flysystem": "^3.10.0",
+                "league/mime-type-detection": "^1.0.0",
+                "php": "^8.0.2"
+            },
+            "conflict": {
+                "guzzlehttp/guzzle": "<7.0",
+                "guzzlehttp/ringphp": "<1.1.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "League\\Flysystem\\AwsS3V3\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Frank de Jonge",
+                    "email": "info@frankdejonge.nl"
+                }
+            ],
+            "description": "AWS S3 filesystem adapter for Flysystem.",
+            "keywords": [
+                "Flysystem",
+                "aws",
+                "file",
+                "files",
+                "filesystem",
+                "s3",
+                "storage"
+            ],
+            "support": {
+                "source": "https://github.com/thephpleague/flysystem-aws-s3-v3/tree/3.24.0"
+            },
+            "funding": [
+                {
+                    "url": "https://ecologi.com/frankdejonge",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/frankdejonge",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-01-26T18:43:21+00:00"
+        },
+        {
             "name": "league/flysystem-local",
             "version": "3.18.0",
             "source": {
@@ -2286,6 +2500,72 @@
                 }
             ],
             "time": "2023-10-27T15:25:26+00:00"
+        },
+        {
+            "name": "mtdowling/jmespath.php",
+            "version": "2.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/jmespath/jmespath.php.git",
+                "reference": "bbb69a935c2cbb0c03d7f481a238027430f6440b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/jmespath/jmespath.php/zipball/bbb69a935c2cbb0c03d7f481a238027430f6440b",
+                "reference": "bbb69a935c2cbb0c03d7f481a238027430f6440b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5 || ^8.0",
+                "symfony/polyfill-mbstring": "^1.17"
+            },
+            "require-dev": {
+                "composer/xdebug-handler": "^3.0.3",
+                "phpunit/phpunit": "^8.5.33"
+            },
+            "bin": [
+                "bin/jp.php"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.7-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/JmesPath.php"
+                ],
+                "psr-4": {
+                    "JmesPath\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Declaratively specify how to extract elements from a JSON document",
+            "keywords": [
+                "json",
+                "jsonpath"
+            ],
+            "support": {
+                "issues": "https://github.com/jmespath/jmespath.php/issues",
+                "source": "https://github.com/jmespath/jmespath.php/tree/2.7.0"
+            },
+            "time": "2023-08-25T10:54:48+00:00"
         },
         {
             "name": "nesbot/carbon",

--- a/database/migrations/2024_03_13_001725_change_column_file_path_varchar_at_racket_images_table.php
+++ b/database/migrations/2024_03_13_001725_change_column_file_path_varchar_at_racket_images_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('racket_images', function (Blueprint $table) {
+            $table->string('file_path', 255)->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('racket_images', function (Blueprint $table) {
+            $table->string('file_path', 70)->change();
+        });
+    }
+};

--- a/database/seeders/RacketImageSeeder.php
+++ b/database/seeders/RacketImageSeeder.php
@@ -16,10 +16,12 @@ class RacketImageSeeder extends Seeder
      */
     public function run()
     {
+        $appUrl = env("APP_URL");
+        
         DB::table('racket_images')->insert([
             [
                 'posting_user_id' => 1,
-                'file_path' => 'images/rackets/default_racket_image1.png',
+                'file_path' => "{$appUrl}/storage/images/rackets/default_racket_image1.png",
                 'title' => 'スピード',
                 'maker_id' => 3,
                 'created_at' => Carbon::now(),
@@ -27,7 +29,7 @@ class RacketImageSeeder extends Seeder
             ],
             [
                 'posting_user_id' => 4,
-                'file_path' => 'images/rackets/default_racket_image2.png',
+                'file_path' => "{$appUrl}/storage/images/rackets/default_racket_image2.png",
                 'title' => 'Vコア',
                 'maker_id' => 2,
                 'created_at' => Carbon::now(),
@@ -35,7 +37,7 @@ class RacketImageSeeder extends Seeder
             ],
             [
                 'posting_user_id' => 2,
-                'file_path' => 'images/rackets/default_racket_image3.png',
+                'file_path' => "{$appUrl}/storage/images/rackets/default_racket_image3.png",
                 'title' => 'プロスタッフ',
                 'maker_id' => 1,
                 'created_at' => Carbon::now(),
@@ -43,7 +45,7 @@ class RacketImageSeeder extends Seeder
             ],
             [
                 'posting_user_id' => 1,
-                'file_path' => 'images/rackets/default_racket_image4.png',
+                'file_path' => "{$appUrl}/storage/images/rackets/default_racket_image4.png",
                 'title' => 'ピュアアエロ',
                 'maker_id' => 5,
                 'created_at' => Carbon::now(),
@@ -51,7 +53,7 @@ class RacketImageSeeder extends Seeder
             ],
             [
                 'posting_user_id' => 1,
-                'file_path' => 'images/rackets/default_racket_image5.png',
+                'file_path' => "{$appUrl}/storage/images/rackets/default_racket_image5.png",
                 'title' => 'T-ファイト',
                 'maker_id' => 8,
                 'created_at' => Carbon::now(),
@@ -59,7 +61,7 @@ class RacketImageSeeder extends Seeder
             ],
             [
                 'posting_user_id' => 1,
-                'file_path' => 'images/rackets/default_racket_image6.png',
+                'file_path' => "{$appUrl}/storage/images/rackets/default_racket_image6.png",
                 'title' => 'ウルトラ100',
                 'maker_id' => 1,
                 'created_at' => Carbon::now(),
@@ -67,7 +69,7 @@ class RacketImageSeeder extends Seeder
             ],
             [
                 'posting_user_id' => 1,
-                'file_path' => 'images/rackets/default_racket_image7.png',
+                'file_path' => "{$appUrl}/storage/images/rackets/default_racket_image7.png",
                 'title' => 'Eゾーン',
                 'maker_id' => 2,
                 'created_at' => Carbon::now(),
@@ -75,7 +77,7 @@ class RacketImageSeeder extends Seeder
             ],
             [
                 'posting_user_id' => 1,
-                'file_path' => 'images/rackets/default_racket_image8.png',
+                'file_path' => "{$appUrl}/storage/images/rackets/default_racket_image8.png",
                 'title' => 'グリンタ',
                 'maker_id' => 19,
                 'created_at' => Carbon::now(),
@@ -83,7 +85,7 @@ class RacketImageSeeder extends Seeder
             ],
             [
                 'posting_user_id' => 1,
-                'file_path' => 'images/rackets/default_racket_image9.png',
+                'file_path' => "{$appUrl}/storage/images/rackets/default_racket_image9.png",
                 'title' => 'ピュアドライブ',
                 'maker_id' => 2,
                 'created_at' => Carbon::now(),


### PR DESCRIPTION
### issue
#144 

### 背景
現状は画像ファイルの保存先がlaravelアプリのstorageフォルダ下になっており、これだと本番にデプロイ後にユーザーによって登録された画像ファイルが、新たに修正されたバージョンをデプロイするたびにherokuにアップするdockerイメージと既存の本番環境のイメージとの差異によりユーザーが登録した画像が消えてしまうことが考えられる。なので画像ファイル自体はamazon S3に保存することで上記の問題を解決したい

### 確認手順

- [ ] モデルであるRacketImage.phpを確認する
- [ ] 登録メソッドであるregisterRacketImageメソッド内の61行目付近でstorageフォルダ下に画像が保存される様になっているのが確認できる

### やったこと

- [ ] racket_imagesテーブルのfile_pathカラムにs3からのurlを保存しようとすると文字数制限が足りないため文字数を増やす修正をした
- [ ] 画像登録処理のRacketImageモデルで定義していたregisterRacketImageメソッドをファイルの保存先をamazon S3に保存される様に修正
- [ ] RacketImageControllerのupdateメソッドでの画像の更新処理をamazon s3上の画像も更新できる様に修正
- [ ] 同じくdestoryメソッドでamazon s3上の画像も削除される様に修正

### 備考
Storage::disk('s3')->put()で画像をs3に登録しているがintervention imageを使っているため一時的にアプリのstorageフォルダに画像ファイルを保存してそれをs3にアップロードする方法をとっている。直接intervention imageを通したファイルを保存しようとしたが実態のないファイルが保存されてしまったため、この様にしている。

### 参考にしたサイト
https://qiita.com/kouki_o9/items/dcc40b30924fd3b30787
https://taishou.ne.jp/laravel-s3-connect/
https://qiita.com/ti_and6id/items/08f96d965aed0d85ae23
https://qiita.com/adwyaatd/items/24b587fe44ced5262722
https://izit-infobox.net/blog/2024/01/04/laravel-s3/
https://qiita.com/shiva_it/items/82754ff83acc3fecc21c
https://qiita.com/kt103/items/7642916ba872f9b5893c
https://brainlog.jp/programming/laravel/post-2686/

レビューお願いします