### PR TITLE
modify:gut画像保存先をamazon　s3に変更

### DIFF
--- a/app/Http/Controllers/GutController.php
+++ b/app/Http/Controllers/GutController.php
@@ -45,7 +45,8 @@ class GutController extends Controller
         $validated = $request->validated();
 
         if(empty($validated['image_id'])) {
-            $defaultgutImage = GutImage::where('file_path', '=', 'images/guts/default_gut_image.jpg')->get()[0];
+            $appUrl = env('APP_URL');
+            $defaultgutImage = GutImage::where('file_path', '=', "{$appUrl}/storage/images/guts/default_gut_image.png")->get()[0];
         }
 
         try {

--- a/app/Models/GutImage.php
+++ b/app/Models/GutImage.php
@@ -4,6 +4,8 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Intervention\Image\Facades\Image;
+use Illuminate\Support\Facades\Storage;
 
 class GutImage extends Model
 {
@@ -21,5 +23,68 @@ class GutImage extends Model
 
     public function maker() {
         return $this->belongsTo(Maker::class);
+    }
+
+    // dbリクエスト処理関連
+
+    // ガット画像登録処理
+    public static function registerGutImage($request)
+    {
+        // 画像ファイルリサイジング
+        $file = Image::make($request['file']);
+        $file->orientate();
+        $file->resize(
+            560,
+            null,
+            function ($constraint) {
+                // 縦横比を保持したままにする
+                $constraint->aspectRatio();
+                // 小さい画像は大きくしない
+                $constraint->upsize();
+            }
+        );
+
+        $filename = now()->format('YmdHis') . $request['title'] . "." . $request['file']->extension();
+
+        // storageに保存するためのpathを生成
+        $storagePath = storage_path('app/public/images/guts');
+        $fileLocationFullPath = $storagePath . '/' . $filename;
+
+        try {
+            // intervention imageを使っているためstorageフォルダ下に一時的に保存
+            if ($file->save($fileLocationFullPath)) {
+                $filePath = 'images/guts/' . $filename;
+
+                // 画像をAmazon S3にアップロード
+                if (Storage::disk('s3')->put($filePath, file_get_contents($fileLocationFullPath))) {
+                    // 成功時
+                    // S3上の画像のURLを取得
+                    $s3Url = Storage::disk('s3')->url($filePath);
+                } else {
+                    // 失敗時
+                    throw new Exception('s3への画像アップロードに失敗しました');
+                }
+
+                // データベースにファイルパスを保存などの処理
+                $gut_image = GutImage::create([
+                    'file_path' => $s3Url,
+                    'title' => $request['title'],
+                    'maker_id' => $request['maker_id']
+                ]);
+            }
+
+            return $gut_image;
+        } catch (\Throwable $e) {
+            // s3上に画像登録完了していたらそれをclean up
+            if(isset($s3Url)) {
+                $trimedFilePath = strstr($s3Url, 'images');
+                Storage::disk('s3')->delete($trimedFilePath);
+            }
+
+            throw $e;
+        } finally {
+            // storageに一時的に保存していた画像ファイルを削除
+            unlink($fileLocationFullPath);
+        }
     }
 }

--- a/database/migrations/2024_03_16_093147_change_column_file_path_varchar_at_racket_images_table.php
+++ b/database/migrations/2024_03_16_093147_change_column_file_path_varchar_at_racket_images_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('gut_images', function (Blueprint $table) {
+            $table->string('file_path', 255)->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('gut_images', function (Blueprint $table) {
+            $table->string('file_path', 70)->change();
+        });
+    }
+};

--- a/database/seeders/GutImageSeeder.php
+++ b/database/seeders/GutImageSeeder.php
@@ -17,9 +17,11 @@ class GutImageSeeder extends Seeder
      */
     public function run()
     {
+        $appUrl = env("APP_URL");
+        
         DB::table('gut_images')->insert([
             [
-                'file_path' => 'images/guts/default_gut_image.png',
+                'file_path' => "{$appUrl}/storage/images/guts/default_gut_image.png",
                 'title' => 'デフォルト',
                 'maker_id' => null,
                 'created_at' => Carbon::now(),


### PR DESCRIPTION
### issue
#148 

### 背景
現状は画像ファイルの保存先がlaravelアプリのstorageフォルダ下になっており、これだと本番にデプロイ後にユーザーによって登録された画像ファイルが、新たに修正されたバージョンをデプロイするたびにherokuにアップするdockerイメージと既存の本番環境のイメージとの際によりユーザーが登録した画像が消えてしまうことが考えられる。なので画像ファイル自体はamazon S3に保存することで上記の問題を解決したい

### 確認手順

- [ ] GutImageController.phpを確認する
- [ ] storeメソッドでstorageフォルダ下に画像が保存される様になっているのが確認できる

### やったこと

- [ ] gut_imagesテーブルのfile_pathカラムにs3からのurlを保存しようとすると文字数制限が足りないため文字数を増やす修正をした
- [ ] 画像登録処理をGutImageモデルにregisterGutImageメソッドに切り出し、ファイルの保存先をamazon S3に保存される様に修正
- [ ] GutImageControllerのupdateメソッドでの画像の更新処理をamazon s3上の画像も更新できる様に修正
- [ ] 同じくdestoryメソッドでamazon s3上の画像も削除される様に修正

### 備考
Storage::disk('s3')->put()で画像をs3に登録しているがintervention imageを使っているため一時的にアプリのstorageフォルダに画像ファイルを保存してそれをs3にアップロードする方法をとっている。直接intervention imageを通したファイルを保存しようとしたが実態のないファイルが保存されてしまったため、この様にしている。

### 参考にしたサイト
https://qiita.com/kouki_o9/items/dcc40b30924fd3b30787
https://taishou.ne.jp/laravel-s3-connect/
https://qiita.com/ti_and6id/items/08f96d965aed0d85ae23
https://qiita.com/adwyaatd/items/24b587fe44ced5262722
https://izit-infobox.net/blog/2024/01/04/laravel-s3/
https://qiita.com/shiva_it/items/82754ff83acc3fecc21c
https://qiita.com/kt103/items/7642916ba872f9b5893c
https://brainlog.jp/programming/laravel/post-2686/

レビューお願いします