### PR TITLE
modify:userプロフィール画像ファイル保存先をamazon　s3に変更

### DIFF
--- a/database/migrations/2024_03_16_155617_change_column_file_path_varchar_at_users_table.php
+++ b/database/migrations/2024_03_16_155617_change_column_file_path_varchar_at_users_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('file_path', 255)->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('file_path', 70)->change();
+        });
+    }
+};


### PR DESCRIPTION
### issue
#150 

### 背景
現状は画像ファイルの保存先がlaravelアプリのstorageフォルダ下になっており、これだと本番にデプロイ後にユーザーによって登録された画像ファイルが、新たに修正されたバージョンをデプロイするたびにherokuにアップするdockerイメージと既存の本番環境のイメージとの際によりユーザーが登録した画像が消えてしまうことが考えられる。なので画像ファイル自体はamazon S3に保存することで上記の問題を解決したい

### 確認手順

- [ ] UserController.phpを確認する
- [ ] updateメソッドでstorageフォルダ下に画像が保存される様になっているのが確認できる

### やったこと

- [ ] usersテーブルのfile_pathカラムにs3からのurlを保存しようとすると文字数制限が足りないため文字数を増やす修正をした
- [ ] UserControllerのupdateメソッドでの画像の更新処理をamazon s3上に登録される様に修正

### 備考
Storage::disk('s3')->put()で画像をs3に登録しているがintervention imageを使っているため一時的にアプリのstorageフォルダに画像ファイルを保存してそれをs3にアップロードする方法をとっている。直接intervention imageを通したファイルを保存しようとしたが実態のないファイルが保存されてしまったため、この様にしている。

### 参考にしたサイト
https://qiita.com/kouki_o9/items/dcc40b30924fd3b30787
https://taishou.ne.jp/laravel-s3-connect/
https://qiita.com/ti_and6id/items/08f96d965aed0d85ae23
https://qiita.com/adwyaatd/items/24b587fe44ced5262722
https://izit-infobox.net/blog/2024/01/04/laravel-s3/
https://qiita.com/shiva_it/items/82754ff83acc3fecc21c
https://qiita.com/kt103/items/7642916ba872f9b5893c
https://brainlog.jp/programming/laravel/post-2686/


レビューお願いします