### PR TITLE
add:ユーザーのラケット登録回数の回数制限機能を追加

### DIFF
--- a/app/Http/Controllers/RacketController.php
+++ b/app/Http/Controllers/RacketController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Middleware\CheckRegistrationLimitOfRacket;
 use Illuminate\Http\Request;
 use App\Models\Racket;
 use App\Http\Requests\Racket\RacketStoreRequest;
@@ -15,6 +16,7 @@ class RacketController extends Controller
     public function __construct()
     {
         $this->middleware('auth:admin')->only(['update', 'destroy']);
+        $this->middleware(CheckRegistrationLimitOfRacket::class)->only('store');
     }
 
     /**

--- a/app/Http/Middleware/CheckRegistrationLimitOfRacket.php
+++ b/app/Http/Middleware/CheckRegistrationLimitOfRacket.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Models\Racket;
+use Carbon\Carbon;
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class CheckRegistrationLimitOfRacket
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure(\Illuminate\Http\Request): (\Illuminate\Http\Response|\Illuminate\Http\RedirectResponse)  $next
+     * @return \Illuminate\Http\Response|\Illuminate\Http\RedirectResponse
+     */
+    public function handle(Request $request, Closure $next)
+    {
+        try {
+            // 一般ユーザーで利用していた場合に回数制限
+            if (Auth::guard('user')->check()) {
+                // ログインしているユーザーのIDを取得する例
+                $userId = Auth::guard('user')->id();
+
+                // リクエストがcreateアクションであるかを確認
+                if ($request->route()->getActionMethod() == 'store') {
+                    // 今日の日付で登録された回数を取得
+                    $registrationCount = Racket::where('posting_user_id', $userId)
+                        ->whereDate('created_at', Carbon::today())
+                        ->count();
+
+                    $limitCount = 10;
+                    // 制限を超えていないかをチェック
+                    if ($registrationCount >= $limitCount) {
+                        return response()->json(
+                            [
+                                'errors' => [
+                                    'limit' => [
+                                        "1日に登録できる回数({$limitCount}回)を超えました。1日経ってから再度登録してください"
+                                    ]
+                                ]
+                            ],
+                            403
+                        );
+                    }
+                }
+            }
+        } catch (\Throwable $e) {
+            \Log::error($e->getMessage());
+
+            throw $e;
+        }
+
+        return $next($request);
+    }
+}


### PR DESCRIPTION
### issue
#120 

### 背景：
ユーザーにラケットを登録してもらう様に変更するのとそれに伴ってスパムの様に何個ものラケットデータを登録されるのを防ぐため、ユーザーが可能なラケットの１日の登録回数を制限する

### 確認手順
RacketControllerのstoreメソッドに関して回数制限などがついていないためユーザーが無限に登録処理を行えてしまうのが確認できる

### やったこと

- [ ] ミドルウェアCheckRegistrationLimitOfRacket.phpを作成し、そこでログインユーザーであれば１日の登録回数をチェックし制限する処理を記載、adminの場合は制限確認処理に入らずにstoreメソッドを実行できる様に記載
- [ ] RacketControllerのconstructでコントローラーミドルウェアとしてCheckRegistrationLimitOfRacketミドルウェアをstoreメソッドに適用させた

### 備考
特になし

レビューお願いします



ミドルウェアを作成しコントローラーミドルウェアとして使用している