### PR TITLE
add: racketsテーブルにrelease_yearカラムを追加

### DIFF
--- a/app/Http/Controllers/RacketController.php
+++ b/app/Http/Controllers/RacketController.php
@@ -76,6 +76,7 @@ class RacketController extends Controller
                 'pattern' => $validated['pattern'],
                 'weight' => isset($validated['weight']) ? $validated['weight'] : null,
                 'balance' => isset($validated['balance']) ? $validated['balance'] : null,
+                'release_year' => isset($validated['release_year']) ? $validated['release_year'] : null,
             ]);
 
             DB::commit();
@@ -150,6 +151,7 @@ class RacketController extends Controller
             $racket->pattern   = isset($validated['pattern']) ? $validated['pattern'] : $racket->pattern;
             $racket->weight    = isset($validated['weight']) ? $validated['weight'] : $racket->weight;
             $racket->balance   = isset($validated['balance']) ? $validated['balance'] : $racket->balance;
+            $racket->release_year   = isset($validated['release_year']) ? $validated['release_year'] : $racket->release_year;
 
             if ($racket->save()) {
                 return response()->json('ラケット情報を更新しました', 200);

--- a/app/Http/Requests/Racket/RacketStoreRequest.php
+++ b/app/Http/Requests/Racket/RacketStoreRequest.php
@@ -37,6 +37,7 @@ class RacketStoreRequest extends FormRequest
             'pattern' => ['required', 'string', 'max:15'],
             'weight' => ['nullable', 'integer', 'max:400'],
             'balance' => ['nullable', 'integer', 'max:400'],
+            'release_year' => ['nullable', 'integer', 'max:3000'],
             'agreement' => ['required', 'boolean', new AgreementConfirmation],
             
             // ラケット画像を同時に登録するため個別で必要

--- a/app/Http/Requests/Racket/RacketUpdateRequest.php
+++ b/app/Http/Requests/Racket/RacketUpdateRequest.php
@@ -35,6 +35,7 @@ class RacketUpdateRequest extends FormRequest
             'pattern' => ['nullable', 'string', 'max:15'],
             'weight' => ['nullable', 'integer', 'max:400'],
             'balance' => ['nullable', 'integer', 'max:400'],
+            'release_year' => ['nullable', 'integer', 'max:3000'],
         ];
     }
 }

--- a/app/Models/Racket.php
+++ b/app/Models/Racket.php
@@ -22,6 +22,7 @@ class Racket extends Model
         'weight',
         'balance',
         'agreement',
+        'release_year'
     ];
 
     public function maker()

--- a/database/migrations/2024_03_26_051231_add_column_release_year_to_rackets_table.php
+++ b/database/migrations/2024_03_26_051231_add_column_release_year_to_rackets_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('rackets', function (Blueprint $table) {
+            $table->integer('release_year')->length(4)->unsigned()->nullable()->default(null)->after('balance');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('rackets', function (Blueprint $table) {
+            $table->dropColumn('release_year');
+        });
+    }
+};

--- a/database/seeders/RacketSeeder.php
+++ b/database/seeders/RacketSeeder.php
@@ -29,6 +29,7 @@ class RacketSeeder extends Seeder
                 'pattern' => '16/19',
                 'weight' => 300,
                 'balance' => 320,
+                'release_year'=> 2021,
                 'created_at' => Carbon::now(),
                 'updated_at' => Carbon::now()
             ],
@@ -44,6 +45,7 @@ class RacketSeeder extends Seeder
                 'pattern' => '16/19',
                 'weight' => null,
                 'balance' => null,
+                'release_year'=> 2021,
                 'created_at' => Carbon::now(),
                 'updated_at' => Carbon::now()
             ],
@@ -59,6 +61,7 @@ class RacketSeeder extends Seeder
                 'pattern' => '16/19',
                 'weight' => null,
                 'balance' => null,
+                'release_year'=> 2021,
                 'created_at' => Carbon::now(),
                 'updated_at' => Carbon::now()
             ],
@@ -74,6 +77,7 @@ class RacketSeeder extends Seeder
                 'pattern' => '16/19',
                 'weight' => null,
                 'balance' => null,
+                'release_year'=> 2022,
                 'created_at' => Carbon::now(),
                 'updated_at' => Carbon::now()
             ],
@@ -91,6 +95,7 @@ class RacketSeeder extends Seeder
                 'pattern' => '16/19',
                 'weight' => null,
                 'balance' => null,
+                'release_year'=> 2022,
                 'created_at' => Carbon::now(),
                 'updated_at' => Carbon::now()
             ],
@@ -106,6 +111,7 @@ class RacketSeeder extends Seeder
                 'pattern' => '16/19',
                 'weight' => null,
                 'balance' => null,
+                'release_year'=> 2022,
                 'created_at' => Carbon::now(),
                 'updated_at' => Carbon::now()
             ],
@@ -121,6 +127,7 @@ class RacketSeeder extends Seeder
                 'pattern' => '16/19',
                 'weight' => null,
                 'balance' => null,
+                'release_year'=> 2023,
                 'created_at' => Carbon::now(),
                 'updated_at' => Carbon::now()
             ],
@@ -136,6 +143,7 @@ class RacketSeeder extends Seeder
                 'pattern' => '16/19',
                 'weight' => null,
                 'balance' => null,
+                'release_year'=> 2023,
                 'created_at' => Carbon::now(),
                 'updated_at' => Carbon::now()
             ],
@@ -151,6 +159,7 @@ class RacketSeeder extends Seeder
                 'pattern' => '16/19',
                 'weight' => null,
                 'balance' => null,
+                'release_year'=> 2024,
                 'created_at' => Carbon::now(),
                 'updated_at' => Carbon::now()
             ],


### PR DESCRIPTION
### issue
#153 

### 背景
管理の都合上ラケット登録をユーザーも行える様にしているが、ラケットは最新モデルと古いモデルで名前が似ていたり、ラケット自体の外観デザインが似ていたりするので、混同しない様に発売年を登録できる様にして識別できる判断材料を追加しておきたい

### やったこと

- [ ] racketsテーブルにrelease_yearカラムを追加
- [ ] 追加によるRacketSeeder.phpの修正
- [ ] さらにrelease_yearカラムを追加したことによる修正が必要なところの修正

    - store及びupdateメソッドを修正

- [ ] postmanのリクエストの修正

### 備考
racketSearchメソッドは今回は修正していないが、release_yearで検索する必要が出てきた場合はその都度修正予定

レビューお願いします