### PR TITLE
release: v0 0 2 herokuへのデプロイ準備 

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 APP_NAME=Laravel
 APP_ENV=local
-APP_KEY=base64:gzma6NgoUvRdPBhKvAw7SwemOH+neMNEpZENwv3ctqQ=
+APP_KEY=
 APP_DEBUG=true
 APP_URL=http://localhost
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,8 @@ COPY tests/ ./tests/
 COPY vendor/ ./vendor/
 COPY .editorconfig .gitattributes .gitignore apache-start.sh artisan composer.json composer.lock docker-compose.yml Dockerfile heroku.yml phpunit.xml README.md  ./
 
+COPY docker/php/php.production.ini /usr/local/etc/php/php.ini
+
 COPY --from=composer:2.5 /usr/bin/composer /usr/bin/composer
 
 RUN sed -ri -e 's!/var/www/html!/var/www/html/public!g' /etc/apache2/sites-available/*.conf

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -23,6 +23,11 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        //
+        \URL::forceScheme('https');
+        
+        // ペジネーションリンクをhttps対応（.env APP_ENV=localでない場合https化）
+        if (!$this->app->environment('local')) {
+            $this->app['request']->server->set('HTTPS', 'on');
+        }
     }
 }

--- a/docker/php/php.production.ini
+++ b/docker/php/php.production.ini
@@ -700,7 +700,7 @@ auto_globals_jit = On
 ; Its value may be 0 to disable the limit. It is ignored if POST data reading
 ; is disabled through enable_post_data_reading.
 ; https://php.net/post-max-size
-post_max_size = 128M
+post_max_size = 100M
 
 ; Automatically add files before PHP document.
 ; https://php.net/auto-prepend-file
@@ -852,7 +852,7 @@ file_uploads = On
 
 ; Maximum allowed size for uploaded files.
 ; https://php.net/upload-max-filesize
-upload_max_filesize = 128M
+upload_max_filesize = 100M
 
 ; Maximum number of files that can be uploaded via a single request
 max_file_uploads = 20
@@ -1976,9 +1976,9 @@ ldap.max_links = -1
 ; List of headers files to preload, wildcard patterns allowed.
 ;ffi.preload=
 
-[xdebug]
-xdebug.mode=debug
-xdebug.start_with_request = yes
-xdebug.client_host=host.docker.internal
-xdebug.client_port=9003
-xdebug.discover_client_host = 1
+# [xdebug]
+# xdebug.mode=debug
+# xdebug.start_with_request = yes
+# xdebug.client_host=host.docker.internal
+# xdebug.client_port=9003
+# xdebug.discover_client_host = 1


### PR DESCRIPTION
### issue
#155 

### 背景
本番公開できる段階まで開発が進んだためherokuにデプロイする

### デプロイ時に本番環境で遭遇した不具合

- [ ] .env.localのAPP_KEYに本番環境のキーを記載してしまっていたため.env.localファイルのAPP_KEYの値を削除し、本番環境では別のAPP_KEYを生成した
- [ ] 本番環境でのページネーションリンクのurlがhttpsでなくhttpになってしまっておりページ遷移が行えなかったことへの対処（app/Providers/AppServiceProvider.phpを修正）
参考サイト：
https://qiita.com/yyy752/items/a54fec337d236429475b
https://qiita.com/ghibi/items/cb4faa2d86f5866cbfd4
https://qiita.com/takuma-jpn/items/712a3ec7abcd045a087d

- [ ] 本番環境ではvercelのnextjsプロジェクトとherokuのlaravel apiの通信で419エラーが出てしまっており、原因としてcookieに保存されたX-Xsrf-Tokenをリクエストヘッダーに付与できない不具合があり、この原因として各ホストで付与されるurlのドメインが異なるためcorsでエラーとなっていた。解決策としてお名前.comで取得したstrii.net独自ドメインをもとにサブドメインを作成し、フロントをstrii.net、バックエンドをwww.strii.netサブドメインでドメインを同じにして対処した。この時cookieのdomain属性をstrii.netになる様に修正することで最終的にうまく通信できる様になった。
このことに対する質問をした。url:https://teratail.com/questions/jnet6n6txyn641#reply-am2wzs01tzgcg8
参考サイト：
https://teratail.com/questions/369477
https://github.com/vercel/next.js/discussions/36487
https://zuma-lab.com/posts/vercel-onamae-domain-settings
https://www.onamae.com/column/domain/49/
https://doiya.hateblo.jp/entry/2022/03/05/013847
https://qiita.com/tksh8/items/ab3748bcb01316461abe
https://qiita.com/mar-gitacount/items/ee8f5a75cd50ce8ad3ca
https://zenn.dev/ymmt1089/articles/20220506_cookie_domain
https://sakura-bird1.hatenablog.com/entry/2018/03/17/024335

- [ ] 画像を登録する処理の時にアップロードファイルが約2MBを超える場合にherokuの初期の設定値によりアップロードファイルの容量制限がついてエラーとなったため、herokuにプッシュするDockerfileで容量の設定をしたphp.production.iniファイルをphpの設定ファイルとしてイメージにコピーする様にしたところ解決した。
